### PR TITLE
[fix](extended_navigator): fix return type

### DIFF
--- a/auto_route/lib/src/extended_navigator.dart
+++ b/auto_route/lib/src/extended_navigator.dart
@@ -76,7 +76,7 @@ class ExtendedNavigator {
   }
 
   @optionalTypeArgs
-  bool pop<T extends Object>([T result]) => _navigator.pop<T>(result);
+  void pop<T extends Object>([T result]) => _navigator.pop<T>(result);
 
   bool canPop() => _navigator.canPop();
 


### PR DESCRIPTION
extended_navigator.dart:79:56: Error: This expression has type 'void' and can't be used.
  bool pop<T extends Object>([T result]) => _navigator.pop<T>(result);