### PR TITLE
Fix warning and typos

### DIFF
--- a/auto_route_generator/CHANGELOG.md
+++ b/auto_route_generator/CHANGELOG.md
@@ -1,4 +1,8 @@
 # ChangeLog
+## [0.3.2+1]
+- Fix typos
+- Fix warning for "Type Annotate Public APIs"
+
 ## [0.3.2]
 
 - Fix generic arguments are not imported.

--- a/auto_route_generator/lib/router_class_generator.dart
+++ b/auto_route_generator/lib/router_class_generator.dart
@@ -85,12 +85,12 @@ class RouterClassGenerator {
     });
 
     // build unknown route error page if route is not found
-    final unknowRoute =
+    final unknownRoute =
         routes.firstWhere((r) => r.isUnknownRoute == true, orElse: () => null);
-    if (unknowRoute != null) {
+    if (unknownRoute != null) {
       _writeln('default: ');
       _generateRouteBuilder(
-          unknowRoute, '${unknowRoute.className}(settings.name)');
+          unknownRoute, '${unknownRoute.className}(settings.name)');
     } else {
       _writeln('default: return unknownRoutePage(settings.name);');
     }

--- a/auto_route_generator/lib/router_class_generator.dart
+++ b/auto_route_generator/lib/router_class_generator.dart
@@ -242,7 +242,7 @@ class RouterClassGenerator {
       _write('};');
     }
 
-    _writeln('static final navigator = ExtendedNavigator(');
+    _writeln('static final ExtendedNavigator navigator = ExtendedNavigator(');
     if (routesWithGuards.isNotEmpty) {
       _write('_guardedRoutes');
     }

--- a/auto_route_generator/lib/src/router_config_resolver.dart
+++ b/auto_route_generator/lib/src/router_config_resolver.dart
@@ -34,7 +34,7 @@ class RouterConfigResolver {
           classElement.unnamedConstructor.parameters.first.type
                   .getDisplayString() !=
               'String') {
-        throw ("UnknowRoute must have a defualt constructor with a positional String Parameter, MyUnknownRoute(String routeName)");
+        throw ("UnknownRoute must have a default constructor with a positional String Parameter, MyUnknownRoute(String routeName)");
       }
     }
 

--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_route_generator
 description: Generator For AutoRoute which is a route generation library, where everything needed for navigation is automatically generated for you.
-version: 0.3.2
+version: 0.3.2+1
 homepage: https://github.com/Milad-Akarie/auto_route_library
 
 environment:


### PR DESCRIPTION
This PR addresses a static analysis warning for "Type Annotate Public APIs" and while I was looking for where to fix the issue, I found some typos and fixed those too.

The fix for the warning was just to add "ExtendedNavigator" to the declaration of the final field in the generated router class. 