### PR TITLE
Add ability to pass initial route arguments to ExtendedNavigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ class MyApp extends StatelessWidget {
     // the native one by assigning it to it's builder
     // instead of return the nativeNavigator we're returning our ExtendedNavigator
      builder: ExtendedNavigator<Router>(router: Router()),
-     // this's a shorthand for
-     builder: (ctx, nativeNavigator) => ExtendedNavigator<Router>(router: Router())
+     // ExtendedNavigator is just a widget so you can still wrap it with other widgets
+     builder: (ctx, nativeNavigator) => Theme(data:...,
+     child: ExtendedNavigator<Router>(router: Router())
+     ,)
     );
   }
 }
@@ -175,7 +177,7 @@ ExtendedNavigator.ofRouter<Router>().pushSecondScreen(args...)
 | Property                                 | Default value | Definition                                                                               |
 | ---------------------------------------- | ------------- | ---------------------------------------------------------------------------------------- |
 | generateRouteList [bool]                 | false         | if true a list of all routes will be generated                                           |
-| generateNavigationHelperExtension [bool] | false         | if true an Navigator extenstion will be generated with helper push methods of all routes |
+| generateNavigationHelperExtension [bool] | false         | if true a Navigator extenstion will be generated with helper push methods of all routes |
 
 #### CustomAutoRouter
 
@@ -219,41 +221,7 @@ Marks route as a custome route-not-found page. There can be only one unknown rou
 ---
 
 ##### That's the fun part!
-
-You don't actually need to do anything extra. AutoRoute automatically detects your route parameters and handles them for you, and because **Types** are important it will make sure you pass the right argument Type
-
-```dart
-class ProductDetails extends StatelessWidget {
-  final int productId;
-// your route parameters are handled based on
-// your widget route constructor
-  const ProductDetails(this.productId);
-  @override
-  Widget build(BuildContext context)...
-}
-```
-
-#### Generated code for the above example
-
-```dart
- final args = settings.arguments;
-  case Routes.productDetailsRoute:
-   // ProductDetails screen is expecting a productId of type <int>
-   // so we check the passed arguments against it
-    if (hasInvalidArgs<int>(args))
-    // if the passed in args are mistyped, an error route page will be displayed instead
-    return misTypedArgsRoute<int>(args);
-    // otherwise we navigate to the desired screen
-    final typedArgs = args as int;
-    return MaterialPageRoute(
-      builder: (_) => ProductDetails(typedArgs),
-      settings: settings,
-    );
-```
-
-#### Passing multiple arguments (Don't worry, We're not using a dynamic Map!)
-
-Since you can only pass one argument to the Navigator, if you define more then one parameter in your screen constructor autoRoute will automatically generate a class that holds your screen arguments and keep them typed.
+You don't actually need to do anything extra. AutoRoute automatically detects your route parameters and handles them for you, it will automatically generate a class that holds your screen arguments and keep them typed.
 
 ```dart
 class WelcomeScreen extends StatelessWidget {
@@ -317,7 +285,7 @@ class $MyNestedRouter {
 }
 ```
 
-##### Hook up your nested navigator with the Generated Router class
+##### Hook up your nested router with an ExtendedNavigator widget
 
 ```dart
  ExtendedNavigator<MyNestedRouter>(router: MyNestedRouter()),

--- a/auto_route/CHANGELOG.md
+++ b/auto_route/CHANGELOG.md
@@ -1,6 +1,10 @@
 # ChangeLog
+## [0.4.3] Breaking Changes
+- Add ability to pass initial route arguments to ExtendedNavigator
+- Change single route parameters will have argument holder classes too as requested
+- Fix ExtendedNavigator.ofRouter<T>() returns null in inspector mode
 
-## [0.4.2] Breaking Changes
+## [0.4.2]
 - Fix Android soft back button always exists App
 
 ## [0.4.1] Breaking Changes

--- a/auto_route/README.md
+++ b/auto_route/README.md
@@ -91,8 +91,10 @@ class MyApp extends StatelessWidget {
     // the native one by assigning it to it's builder
     // instead of return the nativeNavigator we're returning our ExtendedNavigator
      builder: ExtendedNavigator<Router>(router: Router()),
-     // this's a shorthand for
-     builder: (ctx, nativeNavigator) => ExtendedNavigator<Router>(router: Router())
+     // ExtendedNavigator is just a widget so you can still wrap it with other widgets
+     builder: (ctx, nativeNavigator) => Theme(data:...,
+     child: ExtendedNavigator<Router>(router: Router())
+     ,)
     );
   }
 }
@@ -175,7 +177,7 @@ ExtendedNavigator.ofRouter<Router>().pushSecondScreen(args...)
 | Property                                 | Default value | Definition                                                                               |
 | ---------------------------------------- | ------------- | ---------------------------------------------------------------------------------------- |
 | generateRouteList [bool]                 | false         | if true a list of all routes will be generated                                           |
-| generateNavigationHelperExtension [bool] | false         | if true an Navigator extenstion will be generated with helper push methods of all routes |
+| generateNavigationHelperExtension [bool] | false         | if true a Navigator extenstion will be generated with helper push methods of all routes |
 
 #### CustomAutoRouter
 
@@ -219,41 +221,7 @@ Marks route as a custome route-not-found page. There can be only one unknown rou
 ---
 
 ##### That's the fun part!
-
-You don't actually need to do anything extra. AutoRoute automatically detects your route parameters and handles them for you, and because **Types** are important it will make sure you pass the right argument Type
-
-```dart
-class ProductDetails extends StatelessWidget {
-  final int productId;
-// your route parameters are handled based on
-// your widget route constructor
-  const ProductDetails(this.productId);
-  @override
-  Widget build(BuildContext context)...
-}
-```
-
-#### Generated code for the above example
-
-```dart
- final args = settings.arguments;
-  case Routes.productDetailsRoute:
-   // ProductDetails screen is expecting a productId of type <int>
-   // so we check the passed arguments against it
-    if (hasInvalidArgs<int>(args))
-    // if the passed in args are mistyped, an error route page will be displayed instead
-    return misTypedArgsRoute<int>(args);
-    // otherwise we navigate to the desired screen
-    final typedArgs = args as int;
-    return MaterialPageRoute(
-      builder: (_) => ProductDetails(typedArgs),
-      settings: settings,
-    );
-```
-
-#### Passing multiple arguments (Don't worry, We're not using a dynamic Map!)
-
-Since you can only pass one argument to the Navigator, if you define more then one parameter in your screen constructor autoRoute will automatically generate a class that holds your screen arguments and keep them typed.
+You don't actually need to do anything extra. AutoRoute automatically detects your route parameters and handles them for you, it will automatically generate a class that holds your screen arguments and keep them typed.
 
 ```dart
 class WelcomeScreen extends StatelessWidget {
@@ -317,7 +285,7 @@ class $MyNestedRouter {
 }
 ```
 
-##### Hook up your nested navigator with the Generated Router class
+##### Hook up your nested router with an ExtendedNavigator widget
 
 ```dart
  ExtendedNavigator<MyNestedRouter>(router: MyNestedRouter()),

--- a/auto_route/lib/auto_route.dart
+++ b/auto_route/lib/auto_route.dart
@@ -4,4 +4,3 @@ export 'src/extended_navigator.dart';
 export 'src/route_guard.dart';
 export 'src/auto_route_wrapper.dart';
 export 'src/transitions_builders.dart';
-export 'src/router_base.dart';

--- a/auto_route/lib/src/router_base.dart
+++ b/auto_route/lib/src/router_base.dart
@@ -1,6 +1,38 @@
-import 'package:flutter/material.dart';
+part of 'extended_navigator.dart';
 
 abstract class RouterBase {
   Map<String, List<Type>> get guardedRoutes => null;
   Route<dynamic> onGenerateRoute(RouteSettings settings);
+
+  /// if initial route is guarded we push
+  /// a placeholder route until next distention is
+  /// decided by the route guard
+  var _initialRouteHasNotBeenRedirected = true;
+  Route<dynamic> _onGenerateRoute(
+      RouteSettings settings, Object initialRouteArgs) {
+    final routeName = settings.name;
+    if (routeName == '/') {
+      settings = settings.copyWith(arguments: initialRouteArgs);
+      if (_hasGuards(routeName) && _initialRouteHasNotBeenRedirected) {
+        _initialRouteHasNotBeenRedirected = false;
+        assert(_onRePushInitialRoute != null);
+        _onRePushInitialRoute(settings);
+        return PageRouteBuilder(
+          transitionDuration: const Duration(milliseconds: 0),
+          pageBuilder: (_, __, ___) => Container(
+            color: Colors.white,
+          ),
+        );
+      }
+    }
+
+    return onGenerateRoute(settings);
+  }
+
+  Function(RouteSettings settings) _onRePushInitialRoute;
+
+  bool _hasGuards(String routeName) =>
+      routeName != null &&
+      guardedRoutes != null &&
+      guardedRoutes[routeName] != null;
 }

--- a/auto_route/pubspec.yaml
+++ b/auto_route/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_route
 description: AutoRoute is a route generation library, where everything needed for navigation is automatically generated for you.
-version: 0.4.2
+version: 0.4.3
 homepage: https://github.com/Milad-Akarie/auto_route_library
 
 environment:

--- a/auto_route_generator/CHANGELOG.md
+++ b/auto_route_generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## [0.4.3] Breaking Changes
+- Add ability to pass initial route arguments to ExtendedNavigator
+- Change single route parameters will have argument holder classes too as requested
+- Fix ExtendedNavigator.ofRouter<T>() returns null in inspector mode
+
 ## [0.4.0] Breaking Changes
 - Change using ExtendedNavigator instead of the native Navigator
 - Fix initial route does not go through guards

--- a/auto_route_generator/lib/router_class_generator.dart
+++ b/auto_route_generator/lib/router_class_generator.dart
@@ -109,57 +109,34 @@ class RouterClassGenerator {
   void _generateRoute(RouteConfig r) {
     final constructorParams = StringBuffer('');
 
-    if (r.parameters != null && r.parameters.isNotEmpty) {
-      if (r.parameters.length == 1) {
-        final param = r.parameters[0];
-
-        // show an error page if passed args are not the same as declared args
-        _writeln('if(hasInvalidArgs<${param.type}>(args');
-        if (param.isRequired) {
-          _write(',isRequired:true');
-        }
-        _write('))');
-        _writeln('{return misTypedArgsRoute<${param.type}>(args);}');
-
-        _writeln('final typedArgs = args as ${param.type}');
-        if (param.defaultValueCode != null) {
-          _write(' ?? ${param.defaultValueCode}');
-        }
-        _write(';');
-        if (param.isPositional) {
-          constructorParams.write('typedArgs');
-        } else {
-          constructorParams.write('${param.name}: typedArgs');
-        }
-      } else {
-        // if router has any required params the argument class holder becomes required.
-        final hasRequiredParams =
-            r.parameters.where((p) => p.isRequired).isNotEmpty;
-        // show an error page  if passed args are not the same as declared args
-        _writeln('if(hasInvalidArgs<${r.className}Arguments>(args');
-        if (hasRequiredParams) {
-          _write(',isRequired:true');
-        }
-        _write('))');
-        _writeln('{return misTypedArgsRoute<${r.className}Arguments>(args);}');
-
-        _writeln('final typedArgs = args as ${r.className}Arguments');
-        if (!hasRequiredParams) {
-          _write(' ?? ${r.className}Arguments()');
-        }
-        _write(';');
-
-        r.parameters.asMap().forEach((i, param) {
-          if (param.isPositional) {
-            constructorParams.write('typedArgs.${param.name}');
-          } else {
-            constructorParams.write('${param.name}:typedArgs.${param.name}');
-          }
-          if (i != r.parameters.length - 1) {
-            constructorParams.write(',');
-          }
-        });
+    if (r.parameters?.isNotEmpty == true) {
+      // if router has any required params the argument class holder becomes required.
+      final hasRequiredParams =
+          r.parameters.where((p) => p.isRequired).isNotEmpty;
+      // show an error page  if passed args are not the same as declared args
+      _writeln('if(hasInvalidArgs<${r.className}Arguments>(args');
+      if (hasRequiredParams) {
+        _write(',isRequired:true');
       }
+      _write('))');
+      _writeln('{return misTypedArgsRoute<${r.className}Arguments>(args);}');
+
+      _writeln('final typedArgs = args as ${r.className}Arguments');
+      if (!hasRequiredParams) {
+        _write(' ?? ${r.className}Arguments()');
+      }
+      _write(';');
+
+      r.parameters.asMap().forEach((i, param) {
+        if (param.isPositional) {
+          constructorParams.write('typedArgs.${param.name}');
+        } else {
+          constructorParams.write('${param.name}:typedArgs.${param.name}');
+        }
+        if (i != r.parameters.length - 1) {
+          constructorParams.write(',');
+        }
+      });
     }
 
     final constructor =
@@ -169,16 +146,16 @@ class RouterClassGenerator {
   }
 
   void _generateArgumentHolders() {
-    final routesWithArgsHolders = Map<String, RouteConfig>();
+    final routesWithArgsHolders = <String, RouteConfig>{};
 
     // make sure we only generated holder classes for
-    // routes with 2+ parameters
+    // routes with parameters
     // also prevent duplicate class with the same name from being generated;
-    routes.forEach((r) {
-      if (r.parameters != null && r.parameters.length > 1) {
+    routes.where((r) => r.parameters?.isNotEmpty == true).forEach(
+      (r) {
         routesWithArgsHolders[r.className] = r;
-      }
-    });
+      },
+    );
 
     if (routesWithArgsHolders.isNotEmpty) {
       _generateBoxed('Arguments holder classes');
@@ -327,14 +304,9 @@ class RouterClassGenerator {
     _write(' => pushNamed$genericType(Routes.${route.name}');
     if (route.parameters != null) {
       _write(',arguments: ');
-      if (route.parameters.length == 1) {
-        _write('${route.parameters.first.name}');
-      } else {
-        _write('${route.className}Arguments(');
-        _write(route.parameters.map((p) => '${p.name}: ${p.name}').join(','));
-        _write(')');
-      }
-
+      _write('${route.className}Arguments(');
+      _write(route.parameters.map((p) => '${p.name}: ${p.name}').join(','));
+      _write(')');
       if (route.guards?.isNotEmpty == true) {
         _write(',onReject:onReject');
       }

--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_route_generator
 description: Generator For AutoRoute which is a route generation library, where everything needed for navigation is automatically generated for you.
-version: 0.4.0
+version: 0.4.3
 homepage: https://github.com/Milad-Akarie/auto_route_library
 
 environment:
@@ -10,9 +10,8 @@ dependencies:
   build: ^1.0.0
   source_gen: ^0.9.0
   analyzer: ">=0.39.2 <0.40.0"
-  auto_route:
-    # ^0.4.0
-    path: ../auto_route
+  auto_route: ^0.4.3
+#    path: ../auto_route
 
 dev_dependencies:
   build_runner: ^1.0.0

--- a/example/ios/Flutter/flutter_export_environment.sh
+++ b/example/ios/Flutter/flutter_export_environment.sh
@@ -2,10 +2,9 @@
 # This is a generated file; do not edit or check into version control.
 export "FLUTTER_ROOT=/Users/milad/dev/sdk/flutter"
 export "FLUTTER_APPLICATION_PATH=/Users/milad/AndroidStudioProjects/auto_route/example"
-export "FLUTTER_TARGET=/Users/milad/AndroidStudioProjects/auto_route/example/lib/main.dart"
+export "FLUTTER_TARGET=lib/main.dart"
 export "FLUTTER_BUILD_DIR=build"
 export "SYMROOT=${SOURCE_ROOT}/../build/ios"
 export "FLUTTER_FRAMEWORK_DIR=/Users/milad/dev/sdk/flutter/bin/cache/artifacts/engine/ios"
 export "FLUTTER_BUILD_NAME=1.0.0"
 export "FLUTTER_BUILD_NUMBER=1"
-export "TRACK_WIDGET_CREATION=true"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,6 +14,7 @@ class MyApp extends StatelessWidget {
       builder: ExtendedNavigator<Router>(
         initialRoute: Routes.homeScreen,
         router: Router(),
+        initialRouteArgs: HomeScreenArguments(name: 'name'),
         guards: [AuthGuard()],
       ),
     );

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -1,9 +1,10 @@
-import 'package:example/router/router.dart';
+import 'package:auto_route/auto_route.dart';
+import 'package:example/router/router.gr.dart';
 import 'package:flutter/material.dart';
 
 class HomeScreen extends StatelessWidget {
-  HomeScreen() {
-    print('constructing  Home screen');
+  HomeScreen(String name) {
+    print('constructing  Home screen $name');
   }
   @override
   Widget build(BuildContext context) {
@@ -13,19 +14,12 @@ class HomeScreen extends StatelessWidget {
       body: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          Hero(
-            tag: 'hero',
-            child: Icon(Icons.ac_unit),
-          ),
+
           Container(
             child: Center(
               child: FlatButton(
                 child: Text("Second Screen"),
                 onPressed: () async {
-                  // ExtendedNavigator.of(context)
-                  //     .pushSecondScreen(title: 'title', onReject: (guard) {
-
-                  //     });
 
                   ExtendedNavigator.ofRouter<Router>().pushNamed(
                       Routes.secondScreen,

--- a/example/lib/screens/login_screen.dart
+++ b/example/lib/screens/login_screen.dart
@@ -5,13 +5,10 @@ import 'package:flutter/material.dart';
 class LoginScreen extends StatelessWidget {
   final double id;
 
-  LoginScreen({this.id = 20.0}) {
-    print('constructing  login screen');
-  }
+  LoginScreen({this.id = 20.0});
 
   @override
   Widget build(BuildContext context) {
-    print('building login screen');
     return WillPopScope(
       onWillPop: () async {
         ExtendedNavigator.rootNavigator.pop(false);
@@ -25,6 +22,7 @@ class LoginScreen extends StatelessWidget {
             onPressed: () async {
               ExtendedNavigator.of(context)
                   .pushReplacementNamed(Routes.homeScreen);
+              // ExtendedNavigator.rootNavigator.pop(true);
             },
           ),
         ),

--- a/example/lib/screens/nested_screens/nested_router.gr.dart
+++ b/example/lib/screens/nested_screens/nested_router.gr.dart
@@ -23,11 +23,17 @@ class NestedRouter extends RouterBase {
 
   @override
   Route<dynamic> onGenerateRoute(RouteSettings settings) {
+    print(settings);
     final args = settings.arguments;
     switch (settings.name) {
       case Routes.nestedScreen:
+        if (hasInvalidArgs<NestedScreenArguments>(args)) {
+          return misTypedArgsRoute<NestedScreenArguments>(args);
+        }
+        final typedArgs =
+            args as NestedScreenArguments ?? NestedScreenArguments();
         return MaterialPageRoute<dynamic>(
-          builder: (_) => NestedScreen(),
+          builder: (_) => NestedScreen(typedArgs.x),
           settings: settings,
         );
       case Routes.nestedScreenTwo:
@@ -51,6 +57,12 @@ class NestedRouter extends RouterBase {
 // Arguments holder classes
 //***************************************************************************
 
+//NestedScreen arguments holder class
+class NestedScreenArguments {
+  final int x;
+  NestedScreenArguments({this.x});
+}
+
 //NestedScreenTwo arguments holder class
 class NestedScreenTwoArguments {
   final dynamic title;
@@ -63,7 +75,10 @@ class NestedScreenTwoArguments {
 //***************************************************************************
 
 extension NestedRouterNavigationHelperMethods on ExtendedNavigatorState {
-  Future pushNestedScreen() => pushNamed(Routes.nestedScreen);
+  Future pushNestedScreen({
+    int x,
+  }) =>
+      pushNamed(Routes.nestedScreen, arguments: NestedScreenArguments(x: x));
   Future pushNestedScreenTwo({
     dynamic title,
     String message,

--- a/example/lib/screens/nested_screens/nested_screen.dart
+++ b/example/lib/screens/nested_screens/nested_screen.dart
@@ -3,6 +3,7 @@ import 'package:example/screens/nested_screens/nested_router.gr.dart';
 import 'package:flutter/material.dart';
 
 class NestedScreen extends StatelessWidget {
+  NestedScreen(int x);
   @override
   Widget build(BuildContext context) {
     return Column(

--- a/example/lib/screens/second_screen.dart
+++ b/example/lib/screens/second_screen.dart
@@ -3,36 +3,28 @@ import 'package:flutter/material.dart';
 
 import 'nested_screens/nested_router.gr.dart';
 
-class SecondScreen extends StatelessWidget implements AutoRouteWrapper {
+class SecondScreen extends StatelessWidget {
   final String message;
 
   const SecondScreen({@required String title, this.message});
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        print('will pop called');
-        return true;
-      },
-      child: Scaffold(
-        appBar: AppBar(),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Expanded(
-                child: ExtendedNavigator<NestedRouter>(
-                  router: NestedRouter(),
-                ),
-              )
-            ],
-          ),
+    return Scaffold(
+      appBar: AppBar(),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Expanded(
+              child: ExtendedNavigator<NestedRouter>(
+                router: NestedRouter(),
+                initialRouteArgs: NestedScreenArguments(x: 2),
+              ),
+            )
+          ],
         ),
       ),
     );
   }
-
-  @override
-  Widget get wrappedRoute => Container(child: this);
 }


### PR DESCRIPTION
Change single route parameters will have argument holder classes too as requested
Fix ExtendedNavigator.ofRouter<T>() returns null in inspector mode