### PR TITLE
only ignore dart:core when importing

### DIFF
--- a/auto_route_generator/lib/src/route_paramter_config.dart
+++ b/auto_route_generator/lib/src/route_paramter_config.dart
@@ -58,8 +58,12 @@ class RouteParameterResolver {
   }
 
   Future<String> _resolveLibImport(Element element) async {
-    if (element.source == null || element.source.isInSystemLibrary) {
+    if (element.source == null || isCoreDartType(element.source)) {
       return null;
+    }
+    //if element from a system library but not from dart:core
+    if(element.source.isInSystemLibrary){
+      return getImport(element);
     }
     final assetId = await _resolver.assetIdForElement(element);
     final lib = await _resolver.findLibraryByName(assetId.package);

--- a/auto_route_generator/lib/utils.dart
+++ b/auto_route_generator/lib/utils.dart
@@ -1,6 +1,12 @@
 // general utils
 
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/src/generated/source.dart';
+
+// Checks if source is from dart:core library
+bool isCoreDartType(Source source) {
+  return source.isInSystemLibrary && source.uri.path.startsWith('core/');
+}
 
 String getImport(Element element) {
   // return early if source is null
@@ -11,7 +17,7 @@ String getImport(Element element) {
 
   // we don't need to import core dart types
   // or core flutter types
-  if (!source.isInSystemLibrary) {
+  if (!isCoreDartType(source)) {
     final path = source.uri.toString();
     if (!path.startsWith('package:flutter/')) {
       return "'$path'";


### PR DESCRIPTION
**Fixes #74**

``element.source.isInSystemLibrary``  is returing ``true`` for any source that have ``dart:*`` on the uri.

```dart
//from 'package:analyzer/src/generated/source.dart'
abstract class BasicSource extends Source {
  ...
  @override
  bool get isInSystemLibrary => uri.scheme == 'dart';
  ...
}
```

And as I can see here from the [Dart Docs](https://api.dart.dev/stable/2.7.2/index.html) we need to import any system library to use it except ``dart:core``

> Except for dart:core, you must import a library before you can use it.
