### PR TITLE
Adds routePrefix option and allRoutes getter function code for router class

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ ExtendedNavigator.ofRouter<Router>().pushSecondScreen(args...)
 
 | Property                                 | Default value | Definition                                                                               |
 | ---------------------------------------- | ------------- | ---------------------------------------------------------------------------------------- |
-| generateRouteList [bool]                 | false         | if true a list of all routes will be generated                                           |
 | generateNavigationHelperExtension [bool] | false         | if true a Navigator extenstion will be generated with helper push methods of all routes |
 | generateArgsHolderForSingleParameterRoutes [bool] | true         | if true argument holder classes will always be generated for routes with parameters |
 | useLeadingSlashes [bool] | true         | if true route names will be prefixed with '/' |

--- a/auto_route/README.md
+++ b/auto_route/README.md
@@ -179,7 +179,7 @@ ExtendedNavigator.ofRouter<Router>().pushSecondScreen(args...)
 | generateRouteList [bool]                 | false         | if true a list of all routes will be generated                                           |
 | generateNavigationHelperExtension [bool] | false         | if true a Navigator extenstion will be generated with helper push methods of all routes |
 | generateArgsHolderForSingleParameterRoutes [bool] | true         | if true argument holder classes will always be generated for routes with parameters |
-| useLeadingSlashes [bool] | true         | if true route names will be prefixed with '/' |
+| routePrefix [String] |    ''     | all route paths will be prefixed with this routePrefix String |
 | routesClassName [string] | 'Routes'         | the name of the generated Routes class |
 #### CustomAutoRouter
 

--- a/auto_route/README.md
+++ b/auto_route/README.md
@@ -176,7 +176,6 @@ ExtendedNavigator.ofRouter<Router>().pushSecondScreen(args...)
 
 | Property                                 | Default value | Definition                                                                               |
 | ---------------------------------------- | ------------- | ---------------------------------------------------------------------------------------- |
-| generateRouteList [bool]                 | false         | if true a list of all routes will be generated                                           |
 | generateNavigationHelperExtension [bool] | false         | if true a Navigator extenstion will be generated with helper push methods of all routes |
 | generateArgsHolderForSingleParameterRoutes [bool] | true         | if true argument holder classes will always be generated for routes with parameters |
 | routePrefix [String] |    ''     | all route paths will be prefixed with this routePrefix String |

--- a/auto_route/lib/auto_route_annotations.dart
+++ b/auto_route/lib/auto_route_annotations.dart
@@ -1,6 +1,4 @@
 class AutoRouter {
-  // if true a list of all routes will be generated
-  final bool generateRouteList;
   // if true a Navigator extension will be generated with
   // helper push methods of all routes
   final bool generateNavigationHelperExtension;
@@ -12,10 +10,9 @@ class AutoRouter {
   final String routesClassName;
 
   //This is the prefix for each Route String that is generated
-  final String routePrefix ;
+  final String routePrefix;
 
   const AutoRouter._(
-    this.generateRouteList,
     this.generateNavigationHelperExtension,
     this.generateArgsHolderForSingleParameterRoutes,
     this.routesClassName,
@@ -27,13 +24,11 @@ class AutoRouter {
 // overridden by AutoRoute annotation
 class MaterialAutoRouter extends AutoRouter {
   const MaterialAutoRouter(
-      {bool generateRouteList,
-      bool generateNavigationHelperExtension,
+      {bool generateNavigationHelperExtension,
       bool generateArgsHolderForSingleParameterRoutes,
       String routesClassName,
       String routePrefix})
       : super._(
-            generateRouteList,
             generateNavigationHelperExtension,
             generateArgsHolderForSingleParameterRoutes,
             routesClassName,
@@ -44,13 +39,11 @@ class MaterialAutoRouter extends AutoRouter {
 // overridden by AutoRoute annotation
 class CupertinoAutoRouter extends AutoRouter {
   const CupertinoAutoRouter({
-    bool generateRouteList,
     bool generateNavigationHelperExtension,
     bool generateArgsHolderForSingleParameterRoutes,
     String routesClassName,
     String routePrefix,
   }) : super._(
-          generateRouteList,
           generateNavigationHelperExtension,
           generateArgsHolderForSingleParameterRoutes,
           routesClassName,
@@ -60,13 +53,11 @@ class CupertinoAutoRouter extends AutoRouter {
 
 class AdaptiveAutoRouter extends AutoRouter {
   const AdaptiveAutoRouter({
-    bool generateRouteList,
     bool generateNavigationHelperExtension,
     bool generateArgsHolderForSingleParameterRoutes,
     String routesClassName,
     String routePrefix,
   }) : super._(
-          generateRouteList,
           generateNavigationHelperExtension,
           generateArgsHolderForSingleParameterRoutes,
           routesClassName,
@@ -98,18 +89,17 @@ class CustomAutoRouter extends AutoRouter {
 
   /// passed to the barrierDismissible property in [PageRouteBuilder]
   final bool barrierDismissible;
+
   const CustomAutoRouter(
       {this.transitionsBuilder,
       this.barrierDismissible,
       this.durationInMilliseconds,
       this.opaque,
-      bool generateRouteList,
       bool generateNavigationHelperExtension,
       bool generateArgsHolderForSingleParameterRoutes,
       String routesClassName,
       String routePrefix})
       : super._(
-          generateRouteList,
           generateNavigationHelperExtension,
           generateArgsHolderForSingleParameterRoutes,
           routesClassName,

--- a/auto_route/lib/auto_route_annotations.dart
+++ b/auto_route/lib/auto_route_annotations.dart
@@ -11,17 +11,15 @@ class AutoRouter {
   // defaults to 'Routes'
   final String routesClassName;
 
-  // This only effects non-initial routes
-  // initial routes will always be named "/"
-  // defaults to true
-  final bool useLeadingSlashes;
+  //This is the prefix for each Route String that is generated
+  final String routePrefix ;
 
   const AutoRouter._(
     this.generateRouteList,
     this.generateNavigationHelperExtension,
     this.generateArgsHolderForSingleParameterRoutes,
     this.routesClassName,
-    this.useLeadingSlashes,
+    this.routePrefix,
   );
 }
 
@@ -33,13 +31,13 @@ class MaterialAutoRouter extends AutoRouter {
       bool generateNavigationHelperExtension,
       bool generateArgsHolderForSingleParameterRoutes,
       String routesClassName,
-      bool useLeadingSlashes})
+      String routePrefix})
       : super._(
             generateRouteList,
             generateNavigationHelperExtension,
             generateArgsHolderForSingleParameterRoutes,
             routesClassName,
-            useLeadingSlashes);
+            routePrefix);
 }
 
 // Defaults created routes to CupertinoPageRoute unless
@@ -50,13 +48,13 @@ class CupertinoAutoRouter extends AutoRouter {
     bool generateNavigationHelperExtension,
     bool generateArgsHolderForSingleParameterRoutes,
     String routesClassName,
-    bool useLeadingSlashes,
+    String routePrefix,
   }) : super._(
           generateRouteList,
           generateNavigationHelperExtension,
           generateArgsHolderForSingleParameterRoutes,
           routesClassName,
-          useLeadingSlashes,
+          routePrefix,
         );
 }
 
@@ -66,13 +64,13 @@ class AdaptiveAutoRouter extends AutoRouter {
     bool generateNavigationHelperExtension,
     bool generateArgsHolderForSingleParameterRoutes,
     String routesClassName,
-    bool useLeadingSlashes,
+    String routePrefix,
   }) : super._(
           generateRouteList,
           generateNavigationHelperExtension,
           generateArgsHolderForSingleParameterRoutes,
           routesClassName,
-          useLeadingSlashes,
+          routePrefix,
         );
 }
 
@@ -109,13 +107,13 @@ class CustomAutoRouter extends AutoRouter {
       bool generateNavigationHelperExtension,
       bool generateArgsHolderForSingleParameterRoutes,
       String routesClassName,
-      bool useLeadingSlashes})
+      String routePrefix})
       : super._(
           generateRouteList,
           generateNavigationHelperExtension,
           generateArgsHolderForSingleParameterRoutes,
           routesClassName,
-          useLeadingSlashes,
+          routePrefix,
         );
 }
 

--- a/auto_route/lib/src/router_base.dart
+++ b/auto_route/lib/src/router_base.dart
@@ -2,6 +2,7 @@ part of 'extended_navigator.dart';
 
 abstract class RouterBase {
   Map<String, List<Type>> get guardedRoutes => null;
+  List<String> get allRoutes=>[];
   Route<dynamic> onGenerateRoute(RouteSettings settings);
 
   /// if initial route is guarded we push

--- a/auto_route/lib/src/router_base.dart
+++ b/auto_route/lib/src/router_base.dart
@@ -2,7 +2,7 @@ part of 'extended_navigator.dart';
 
 abstract class RouterBase {
   Map<String, List<Type>> get guardedRoutes => null;
-  List<String> get allRoutes=>[];
+  Set<String> get allRoutes=>[];
   Route<dynamic> onGenerateRoute(RouteSettings settings);
 
   /// if initial route is guarded we push

--- a/auto_route_generator/lib/router_class_generator.dart
+++ b/auto_route_generator/lib/router_class_generator.dart
@@ -64,7 +64,7 @@ class RouterClassGenerator {
     _writeln('abstract class ${_routerConfig.routesClassName} {');
     _routes.forEach((r) {
       final routeName = r.name;
-      final preFix = _routerConfig.useLeadingSlashes ? "/" : "";
+      final preFix = _routerConfig.routePrefix;
       final pathName = r.pathName ?? "$preFix${toKababCase(routeName)}";
       if (r.initial == true) {
         _writeln("static const $routeName = '/';");

--- a/auto_route_generator/lib/router_class_generator.dart
+++ b/auto_route_generator/lib/router_class_generator.dart
@@ -81,6 +81,16 @@ class RouterClassGenerator {
     _writeln('}');
   }
 
+  void _generateRoutesGetterFunction(List<RouteConfig> routes) {
+    _newLine();
+    _writeln('@override');
+    _writeln("List<String> get allRoutes => const [");
+    routes.forEach((r) => _write('${_routerConfig.routesClassName}.${r.name},'));
+    _write("];");
+    _newLine();
+    _newLine();
+  }
+
   void _generateRouteGeneratorFunction(List<RouteConfig> routes) {
     _newLine();
     _writeln('@override');
@@ -235,6 +245,7 @@ class RouterClassGenerator {
 
   void _generateRouterClass() {
     _writeln('\nclass $_className extends RouterBase {');
+    _generateRoutesGetterFunction(_routes);
     _generateHelperFunctions();
     _generateRouteGeneratorFunction(_routes);
 

--- a/auto_route_generator/lib/router_class_generator.dart
+++ b/auto_route_generator/lib/router_class_generator.dart
@@ -83,6 +83,7 @@ class RouterClassGenerator {
 
   void _generateRoutesGetterFunction(List<RouteConfig> routes) {
     _newLine();
+    _newLine();
     _writeln('@override');
     _writeln("List<String> get allRoutes => const [");
     routes.forEach((r) => _write('${_routerConfig.routesClassName}.${r.name},'));

--- a/auto_route_generator/lib/router_class_generator.dart
+++ b/auto_route_generator/lib/router_class_generator.dart
@@ -64,20 +64,18 @@ class RouterClassGenerator {
     _writeln('abstract class ${_routerConfig.routesClassName} {');
     _routes.forEach((r) {
       final routeName = r.name;
-      final preFix = _routerConfig.routePrefix;
-      final pathName = r.pathName ?? "$preFix${toKababCase(routeName)}";
       if (r.initial == true) {
         _writeln("static const $routeName = '/';");
       } else {
-        return _writeln("static const $routeName = '$pathName';");
+        final preFix = _routerConfig.routePrefix;
+        final pathName = r.pathName ?? "$preFix${toKababCase(routeName)}";
+        _writeln("static const $routeName = '$pathName';");
       }
     });
+    _writeln("static const allRoutes = {");
+    _routes.forEach((r) => _write('${r.name},'));
+    _write("};");
 
-    if (_routerConfig.generateRouteList) {
-      _writeln("static const all = [");
-      _routes.forEach((r) => _write('${r.name},'));
-      _write("];");
-    }
     _writeln('}');
   }
 
@@ -85,9 +83,10 @@ class RouterClassGenerator {
     _newLine();
     _newLine();
     _writeln('@override');
-    _writeln("List<String> get allRoutes => const [");
-    routes.forEach((r) => _write('${_routerConfig.routesClassName}.${r.name},'));
-    _write("];");
+    _writeln("Set<String> get allRoutes => const {");
+    routes
+        .forEach((r) => _write('${_routerConfig.routesClassName}.${r.name},'));
+    _write("};");
     _newLine();
     _newLine();
   }

--- a/auto_route_generator/lib/src/route_paramter_config.dart
+++ b/auto_route_generator/lib/src/route_paramter_config.dart
@@ -58,7 +58,7 @@ class RouteParameterResolver {
   }
 
   Future<String> _resolveLibImport(Element element) async {
-    if (element.source == null || isCoreDartType(element.source)) {
+    if (element?.source == null || isCoreDartType(element.source)) {
       return null;
     }
     //if element from a system library but not from dart:core

--- a/auto_route_generator/lib/src/router_config.dart
+++ b/auto_route_generator/lib/src/router_config.dart
@@ -11,7 +11,7 @@ class RouterConfig {
   bool generateRouteList;
   bool generateNavigationHelper;
   bool generateArgsHolderForSingleParameterRoutes;
-  bool useLeadingSlashes;
+  String routePrefix;
 
   final globalRouteConfig = RouteConfig();
   String routesClassName;
@@ -26,7 +26,7 @@ class RouterConfig {
             .peek('generateArgsHolderForSingleParameterRoutes')
             ?.boolValue ??
         true;
-    useLeadingSlashes = autoRouter.peek('useLeadingSlashes')?.boolValue ?? true;
+    routePrefix = autoRouter.peek('routePrefix')?.stringValue ?? '' ;
 
     routesClassName =
         autoRouter.peek('routesClassName')?.stringValue ?? 'Routes';

--- a/auto_route_generator/lib/src/router_config.dart
+++ b/auto_route_generator/lib/src/router_config.dart
@@ -8,7 +8,6 @@ import '../utils.dart';
 /// to be used in [RouterClassGenerator]
 
 class RouterConfig {
-  bool generateRouteList;
   bool generateNavigationHelper;
   bool generateArgsHolderForSingleParameterRoutes;
   String routePrefix;
@@ -17,8 +16,6 @@ class RouterConfig {
   String routesClassName;
 
   RouterConfig.fromAnnotation(ConstantReader autoRouter) {
-    generateRouteList =
-        autoRouter.peek('generateRouteList')?.boolValue ?? false;
     generateNavigationHelper =
         autoRouter.peek('generateNavigationHelperExtension')?.boolValue ??
             false;


### PR DESCRIPTION
## Related Issues : 
#88 
#90 

## Results based on this code : 

This is my $Router class : 

### $Router class 

```dart
@MaterialAutoRouter(routesClassName: 'BusRoute', generateRouteList: true , routePrefix: '/bus/')
class $MyBusRouter{
  BusFilterScreen busFilterScreen ;
  BaseLoadingScreen baseLoadingScreen ; 
}
```

### Generated Class : 

```dart
abstract class BusRoute {
  static const busFilterScreen = '/bus/bus-filter-screen';
  static const baseLoadingScreen = '/bus/base-loading-screen';
  static const all = [
    busFilterScreen,
    baseLoadingScreen,
  ];
}

class MyBusRouter extends RouterBase {
  @override
  List<String> get allRoutes => const [
        BusRoute.busFilterScreen,
        BusRoute.baseLoadingScreen,
      ];

  //This will probably be removed in future versions
  //you should call ExtendedNavigator.ofRouter<Router>() directly
  static ExtendedNavigatorState get navigator =>
      ExtendedNavigator.ofRouter<MyBusRouter>();

  @override
  Route<dynamic> onGenerateRoute(RouteSettings settings) {
    final args = settings.arguments;
    switch (settings.name) {
      case BusRoute.busFilterScreen:
        if (hasInvalidArgs<BusFilterScreenArguments>(args, isRequired: true)) {
          return misTypedArgsRoute<BusFilterScreenArguments>(args);
        }
        final typedArgs = args as BusFilterScreenArguments;
        return MaterialPageRoute<dynamic>(
          builder: (context) => BusFilterScreen(
              key: typedArgs.key,
              tripId: typedArgs.tripId,
              filterScreenManager: typedArgs.filterScreenManager),
          settings: settings,
        );
      case BusRoute.baseLoadingScreen:
        if (hasInvalidArgs<BaseLoadingScreenArguments>(args)) {
          return misTypedArgsRoute<BaseLoadingScreenArguments>(args);
        }
        final typedArgs =
            args as BaseLoadingScreenArguments ?? BaseLoadingScreenArguments();
        return MaterialPageRoute<dynamic>(
          builder: (context) => BaseLoadingScreen(
              key: typedArgs.key,
              showAppBar: typedArgs.showAppBar,
              appBarTitle: typedArgs.appBarTitle,
              showThreeDotMenu: typedArgs.showThreeDotMenu),
          settings: settings,
        );
      default:
        return unknownRoutePage(settings.name);
    }
  }
}
```

### Regarding issue #90 

I will raise a separate PR to convert the `List` getter into a `Set` getter for optimisation purpose.

Thank you for this awesome library 😄 
will try to add a PR for fixing issue #91  , but I have no idea how I might fix it . May be you can help me here :)  



