### PR TITLE
ref(navigator): Report route update

### DIFF
--- a/auto_route/lib/src/extended_navigator.dart
+++ b/auto_route/lib/src/extended_navigator.dart
@@ -252,6 +252,7 @@ class ExtendedNavigatorState<T extends RouterBase>
         return router.onGenerateRoute(settings, basePath);
       },
       onUnknownRoute: widget.onUnknownRoute ?? defaultUnknownRoutePage,
+      reportsRouteUpdateToEngine: true,
       onGenerateInitialRoutes: (NavigatorState navigator, String initialRoute) {
         var initialUri;
         if (parentData != null) {


### PR DESCRIPTION
Since the last flutter update, navigation on the web was working without the route being updated on the browser url.
This quick change makes it work in my case, but I don't have the knowledge to know if it will work for everybody else, I notice the problem also occurs with flutter native navigator when using onGenerateRoute, so it's probably not even an error with your plugin.
Also, the plugin is great, keep it up 👍 