### PR TITLE
Add factory pageView constructor to AutoTabsRouter

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -5,26 +5,31 @@ import 'package:flutter/material.dart';
 import '../../../auto_route.dart';
 import '../controller/routing_controller.dart';
 
-typedef AnimatedIndexedStackBuilder = Widget Function(BuildContext context, Widget child, Animation<double> animation);
+typedef AnimatedIndexedStackBuilder = Widget Function(
+    BuildContext context, Widget child, Animation<double> animation);
+
+typedef PageViewBuilder = Widget Function(
+    BuildContext context, List<Widget> children, TabsRouter controller);
 
 class AutoTabsRouter extends StatefulWidget {
-  final AnimatedIndexedStackBuilder builder;
-  final List<PageRouteInfo> routes;
-  final Duration duration;
-  final Curve curve;
-  final bool lazyLoad;
+  const AutoTabsRouter._({Key key}) : super(key: key);
 
-  const AutoTabsRouter({
+  factory AutoTabsRouter.indexedStack({
     Key key,
-    @required this.routes,
-    this.lazyLoad = true,
-    this.duration = const Duration(milliseconds: 300),
-    this.curve = Curves.ease,
-    this.builder,
-  }) : super(key: key);
+    @required List<PageRouteInfo> routes,
+    @required AnimatedIndexedStackBuilder builder,
+    bool lazyLoad,
+    Duration duration,
+    Curve curve,
+  }) = _IndexedStackRouter;
 
-  @override
-  AutoTabsRouterState createState() => AutoTabsRouterState();
+  factory AutoTabsRouter.pageView({
+    Key key,
+    @required List<PageRouteInfo> routes,
+    @required PageViewBuilder builder,
+    PageController pageController,
+    int initialIndex,
+  }) = _PageViewRouter;
 
   static TabsRouter of(BuildContext context) {
     var scope = TabsRouterScope.of(context);
@@ -39,9 +44,143 @@ class AutoTabsRouter extends StatefulWidget {
     }());
     return scope.controller;
   }
+
+  @override
+  State<StatefulWidget> createState() {
+    throw UnimplementedError();
+  }
 }
 
-class AutoTabsRouterState extends State<AutoTabsRouter> with SingleTickerProviderStateMixin {
+class _IndexedStackRouter extends AutoTabsRouter {
+  final List<PageRouteInfo> routes;
+
+  final AnimatedIndexedStackBuilder builder;
+
+  final Duration duration;
+
+  final Curve curve;
+
+  final bool lazyLoad;
+
+  const _IndexedStackRouter({
+    Key key,
+    @required this.routes,
+    this.lazyLoad = true,
+    this.duration = const Duration(milliseconds: 300),
+    this.curve = Curves.ease,
+    this.builder,
+  }) : super._(key: key);
+
+  @override
+  _AutoTabsRouterIndexedState createState() => _AutoTabsRouterIndexedState();
+}
+
+class _PageViewRouter extends AutoTabsRouter {
+  final List<PageRouteInfo> routes;
+
+  final PageViewBuilder builder;
+
+  /// This is a very special comment to me [bokuma]
+  final PageController pageController;
+
+  final int initialIndex;
+
+  const _PageViewRouter({
+    Key key,
+    @required this.routes,
+    @required this.pageController,
+    this.builder = _defaultBuilder,
+    this.initialIndex = 0,
+  }) : super._(key: key);
+
+  static Widget _defaultBuilder(_, child, animation) {
+    return FadeTransition(opacity: animation, child: child);
+  }
+
+  @override
+  _AutoTabsRouterPageViewState createState() => _AutoTabsRouterPageViewState();
+}
+
+class _AutoTabsRouterPageViewState extends State<_PageViewRouter> {
+  TabsRouter _controller;
+  int _index;
+
+  TabsRouter get controller => _controller;
+
+  @override
+  void initState() {
+    _index = widget.initialIndex;
+    super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_controller == null) {
+      final entry = StackEntryScope.of(context);
+      assert(entry is RoutingController);
+
+      _controller = entry as RoutingController;
+      _index = _controller.activeIndex;
+      _resetController();
+    }
+  }
+
+  void _resetController() {
+    assert(_controller != null);
+    _controller.setupRoutes(widget.routes);
+
+    final rootDelegate = RootRouterDelegate.of(context);
+
+    _controller.addListener(() {
+      if (_controller.activeIndex != _index) {
+        widget.pageController.jumpToPage(_controller.activeIndex);
+
+        setState(() {
+          _index = _controller.activeIndex;
+        });
+
+        rootDelegate.notify();
+      }
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant _PageViewRouter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _controller.setupRoutes(widget.routes);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final stack = _controller.stack;
+
+    return RoutingControllerScope(
+      controller: _controller,
+      child: TabsRouterScope(
+        controller: _controller,
+        child: Builder(
+          builder: (context) {
+            return widget.builder(
+              context,
+              stack.map((item) => item.wrappedChild(context)).toList(),
+              _controller,
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _AutoTabsRouterIndexedState extends State<_IndexedStackRouter>
+    with SingleTickerProviderStateMixin {
   TabsRouter _controller;
   AnimationController _animationController;
   Animation<double> _animation;
@@ -110,7 +249,7 @@ class AutoTabsRouterState extends State<AutoTabsRouter> with SingleTickerProvide
   Widget build(BuildContext context) {
     assert(_controller != null);
     final stack = _controller.stack;
-    final builder = widget.builder ?? _defaultBuilder;
+    final builder = widget.builder;
     return RoutingControllerScope(
       controller: _controller,
       child: TabsRouterScope(
@@ -130,10 +269,6 @@ class AutoTabsRouterState extends State<AutoTabsRouter> with SingleTickerProvide
                   ),
           )),
     );
-  }
-
-  Widget _defaultBuilder(_, child, animation) {
-    return FadeTransition(opacity: animation, child: child);
   }
 }
 
@@ -180,7 +315,8 @@ class _IndexedStackBuilderState extends State<_IndexedStackBuilder> {
   void didUpdateWidget(_IndexedStackBuilder oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.lazyLoad && _pages[widget.activeIndex] is _DummyWidget) {
-      _pages[widget.activeIndex] = widget.itemBuilder(context, widget.activeIndex);
+      _pages[widget.activeIndex] =
+          widget.itemBuilder(context, widget.activeIndex);
     }
   }
 

--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -16,7 +16,7 @@ class AutoTabsRouter extends StatefulWidget {
 
   factory AutoTabsRouter.indexedStack({
     Key key,
-    @required List<PageRouteInfo> routes,
+    List<PageRouteInfo> routes,
     @required AnimatedIndexedStackBuilder builder,
     bool lazyLoad,
     Duration duration,
@@ -64,7 +64,7 @@ class _IndexedStackRouter extends AutoTabsRouter {
 
   const _IndexedStackRouter({
     Key key,
-    @required this.routes,
+    this.routes = const [],
     this.lazyLoad = true,
     this.duration = const Duration(milliseconds: 300),
     this.curve = Curves.ease,

--- a/example/lib/mobile/screens/home_page.dart
+++ b/example/lib/mobile/screens/home_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 class HomePage extends StatelessWidget {
   @override
-  Widget build(_) => AutoTabsRouter(
+  Widget build(_) => AutoTabsRouter.indexedStack(
         routes: [BooksTab(), ProfileTab(), SettingsTab()],
         duration: Duration(milliseconds: 400),
         builder: (context, child, animation) {

--- a/example/lib/mobile/screens/settings_tab_page.dart
+++ b/example/lib/mobile/screens/settings_tab_page.dart
@@ -1,16 +1,15 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:example/mobile/router/router.gr.dart';
 import 'package:flutter/material.dart';
 
 class SettingsTabPage extends StatelessWidget {
   @override
-  Widget build(_) => AutoTabsRouter(
+  Widget build(_) => AutoTabsRouter.indexedStack(
         duration: Duration(milliseconds: 400),
         builder: (context, child, animation) {
           var tabsRouter = context.tabsRouter;
           return Scaffold(
             appBar: AppBar(
-              title: Text(tabsRouter.currentRoute?.name),
+              title: Text(tabsRouter.current?.name),
             ),
             body: FadeTransition(child: child, opacity: animation),
             bottomNavigationBar: buildBottomNav(tabsRouter),


### PR DESCRIPTION
Related to #311 

This is currently a breaking change as I honestly don't know how to keep the default constructor and still make it work. The two constructors don't share much in common besides the `routes` field and I didn't want to make a delegate although maybe I could. Factories are a bit confusing to me but feel free to offer any advice

- [ ] update version
- [ ] update changelog
- [ ] add tests