### PR TITLE
Proof of Concept for SharedPartBuilder

### DIFF
--- a/auto_route_generator/build.yaml
+++ b/auto_route_generator/build.yaml
@@ -2,6 +2,7 @@ builders:
   autoRouteGenerator:
     import: "package:auto_route_generator/builder.dart"
     builder_factories: ["autoRouteGenerator"]
-    build_extensions: {'.dart': ['.gr.dart']}
+    build_extensions: {'.dart': ['.auto_route.g.dart']}
     auto_apply: dependents
-    build_to: source
+    build_to: cache
+    applies_builders: ["source_gen|combining_builder"]

--- a/auto_route_generator/lib/builder.dart
+++ b/auto_route_generator/lib/builder.dart
@@ -4,9 +4,10 @@ import 'package:source_gen/source_gen.dart';
 import 'auto_route_generator.dart';
 
 Builder autoRouteGenerator(BuilderOptions options) {
-  // gr stands for generated router.
-  return LibraryBuilder(
-    AutoRouteGenerator(),
-    generatedExtension: '.gr.dart',
+  return SharedPartBuilder(
+    [
+      AutoRouteGenerator(),
+    ],
+    'auto_route',
   );
 }

--- a/auto_route_generator/lib/src/code_builder/library_builder.dart
+++ b/auto_route_generator/lib/src/code_builder/library_builder.dart
@@ -51,6 +51,6 @@ String generateLibrary(RouterConfig config) {
       ]),
   );
 
-  final emitter = DartEmitter(Allocator.simplePrefixing(), true, true);
+  final emitter = DartEmitter(Allocator.none, true, true);
   return DartFormatter().format(library.accept(emitter).toString());
 }

--- a/auto_route_generator/lib/src/router_config_resolver.dart
+++ b/auto_route_generator/lib/src/router_config_resolver.dart
@@ -83,11 +83,11 @@ class RouterConfigResolver {
   RouterConfig resolve(ConstantReader autoRouter, ClassElement clazz) {
     /// ensure router config classes are prefixed with $
     /// to use the stripped name for the generated class
-    throwIf(
-      !clazz.displayName.startsWith(r'$'),
-      'Router class name must be prefixed with \$',
-      element: clazz,
-    );
+    // throwIf(
+    //   !clazz.displayName.startsWith(r'$'),
+    //   'Router class name must be prefixed with \$',
+    //   element: clazz,
+    // );
 
     var globalRouteConfig = RouteConfig();
     if (autoRouter.instanceOf(TypeChecker.fromRuntime(CupertinoAutoRouter))) {
@@ -136,7 +136,7 @@ class RouterConfigResolver {
 
     var routerConfig = RouterConfig(
         globalRouteConfig: globalRouteConfig,
-        routerClassName: clazz.displayName.substring(1),
+        routerClassName: '_\$${clazz.displayName}',
         element: clazz,
         routesClassName: routesClassName,
         routeNamePrefix: routeNamePrefix,


### PR DESCRIPTION
After not using auto_route for a while but now testing it a lot due to Nav 2.0 I remembered an old issue: https://github.com/Milad-Akarie/auto_route_library/issues/6

This is now possible due to the fact that now all config is part of the annotation and not of the class body.
It also reduces the work needed in the generator since imports no longer need to be resolved. (i have not removed that part yet).

`part of` files do not allow imports so everything needs to be imported in the `app_router.dart` file, which it is anyway.

```dart
part ' app_router.g.dart`;

@MaterialAutoRouter(
  ...
)
class AppRouter extends _$AppRouter {}
```

Generates:

```dart
// GENERATED CODE - DO NOT MODIFY BY HAND

part of 'app_router.dart';

// **************************************************************************
// AutoRouteGenerator
// **************************************************************************

class _$AppRouter extends RootStackRouter {
  _$AppRouter();
  
  ...
}
```


This will probably also work for legacy mode, but needs to be tested.


Just wondering what you think about this @Milad-Akarie 