### PR TITLE
Autor Router constructor : required and assert fix

### DIFF
--- a/auto_route_generator/lib/src/code_builder/root_router_builder.dart
+++ b/auto_route_generator/lib/src/code_builder/root_router_builder.dart
@@ -38,14 +38,8 @@ Class buildRouterConfig(RouterConfig router, Set<ImportableType> guards,
                 ..name = toLowerCamelCase(g.name)
                 ..named = true
                 ..toThis = true
-                ..annotations.add(requiredAnnotation)),
+                ..required = true),
             ),
-          ])
-          ..initializers.addAll([
-            ...guards.map((g) => refer('assert').call([
-                  refer(toLowerCamelCase(g.toString()))
-                      .notEqualTo(refer('null')),
-                ]).code),
           ])),
         // ),
       ));


### PR DESCRIPTION
Replaced material import "required annotations" with the "required" keyword
Removed assert null checks from the constructor