### PR TITLE
Merge declared route args into route generated from MatchRoute

### DIFF
--- a/auto_route/lib/src/route/page_route_info.dart
+++ b/auto_route/lib/src/route/page_route_info.dart
@@ -66,7 +66,24 @@ class PageRouteInfo<T> {
         params = match.pathParams.rawMap,
         queryParams = match.queryParams.rawMap,
         initialChildren =
-            match.children?.map((m) => PageRouteInfo.fromMatch(m)).toList();
+        match.children?.map((m) => PageRouteInfo.fromMatch(m)).toList();
+
+  PageRouteInfo copy({
+    String? name,
+    String? path,
+    T? args,
+    RouteMatch? match,
+    Map<String, dynamic>? params,
+    Map<String, dynamic>? queryParams,
+    List<PageRouteInfo>? initialChildren}) =>
+      PageRouteInfo(
+          name ?? this._name,
+          path: path ?? this.path,
+          args: args ?? this.args,
+          match: match ?? this.match,
+          params: params ?? this.params,
+          queryParams: queryParams ?? this.queryParams
+      );
 
 // maybe?
   Future<void> show(BuildContext context) {

--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -249,9 +249,10 @@ class ParallelBranchEntry extends ChangeNotifier
         (r) => r.routeName == preMatchedRoute.routeName,
       );
       if (correspondingRouteIndex != -1) {
+        final currentRoute = routes[correspondingRouteIndex];
         routesToPush
           ..removeAt(correspondingRouteIndex)
-          ..insert(correspondingRouteIndex, preMatchedRoute);
+          ..insert(correspondingRouteIndex, preMatchedRoute.copy(args: currentRoute.args));
         _activeIndex = correspondingRouteIndex;
       }
     }


### PR DESCRIPTION
On `pushPath` call,  a `PageRouteInfo` is built from `RouteMatch` so any declared `args` are missing. The goal here is to retrieve these args and filling the route before pushing it