### PR TITLE
Add TransitionsBuilder.none

### DIFF
--- a/auto_route/lib/src/common/transitions_builders.dart
+++ b/auto_route/lib/src/common/transitions_builders.dart
@@ -3,6 +3,13 @@
 import 'package:flutter/material.dart';
 
 class TransitionsBuilders {
+  static const RouteTransitionsBuilder none = _none;
+
+  static Widget _none(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation, Widget child) {
+    return child;
+  }
+
   static const RouteTransitionsBuilder slideRight = _slideRight;
 
   static Widget _slideRight(BuildContext context, Animation<double> animation,


### PR DESCRIPTION
To make the Flutter UXR Nesting scenario more concise