### PR TITLE
Add EmptyRouterScreen

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_router.dart
@@ -272,3 +272,8 @@ class _DeclarativeAutoRouterState extends State<_DeclarativeAutoRouter> {
 class EmptyRouterPage extends AutoRouter {
   const EmptyRouterPage({Key? key}) : super(key: key);
 }
+
+
+class EmptyRouterScreen extends AutoRouter {
+  const EmptyRouterScreen({Key? key}) : super(key: key);
+}


### PR DESCRIPTION
Since all of the Flutter_UXR examples name their widgets with "Screen" instead of "Page", it will make the snippets much more concise if there is an `EmptyRouterScreen`