### PR TITLE
Fix mobile example of auto_route

### DIFF
--- a/auto_route/example/lib/mobile/screens/books/book_list_page.dart
+++ b/auto_route/example/lib/mobile/screens/books/book_list_page.dart
@@ -25,9 +25,7 @@ class _BookListPageState extends State<BookListPage> with AutoRouteAware {
                             title: Text(book.name),
                             subtitle: Text(book.genre),
                             onTap: () {
-                              // BookDetailsRoute(id: book.id).show(context);
                               context.router.pushAll([
-                                BookDetailsRoute(id: book.id),
                                 BookDetailsRoute(id: book.id),
                               ]);
                             },


### PR DESCRIPTION
Hi during my tests I found a little mistake in the example section.
I just removed two lines from the book list page.