### PR TITLE
docs: code syntax error on 'Finalize the setup' section for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ flutter packages pub run build_runner build
 #### Finalize the setup    
  after you run the generator your router class will be generated, hook it up with MaterialApp.    
 ```dart    
-class App extends StatlessWidget{
+class App extends StatlessWidget {
   // make sure you don't initiate your router
   // inside of the build function.
    final _appRouter = AppRouter();    
    
-  Widget build(BuildContext context){    
+  Widget build(BuildContext context) {    
       return MaterialApp.router(    
-             routerDelegate: AutoRouterDelegeate(_appDelegate),
+             routerDelegate: AutoRouterDelegate(_appRouter),
              // or
              // routerDelegate:_appDelegate.delegate(),    
              routeInformationParser: _appRouter.defaultRouteParser(),    

--- a/README.md
+++ b/README.md
@@ -87,19 +87,20 @@ flutter packages pub run build_runner build
 #### Finalize the setup    
  after you run the generator your router class will be generated, hook it up with MaterialApp.    
 ```dart    
-class App extends StatlessWidget {
+class App extends StatelessWidget {
   // make sure you don't initiate your router
   // inside of the build function.
-   final _appRouter = AppRouter();    
-   
-  Widget build(BuildContext context) {    
-      return MaterialApp.router(    
-             routerDelegate: AutoRouterDelegate(_appRouter),
-             // or
-             // routerDelegate:_appDelegate.delegate(),    
-             routeInformationParser: _appRouter.defaultRouteParser(),    
-         ),    
-  }    
+  final _appRouter = AppRouter();
+
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routerDelegate: AutoRouterDelegate(_appRouter),
+      // or
+      // routerDelegate:_appRouter.delegate(),    
+      routeInformationParser: _appRouter.defaultRouteParser(),
+    );
+  }
+} 
 ```    
 ## Generated Routes  
  A `PageRouteInfo` object will be generated for every declared AutoRoute, These objects hold path information plus strongly-typed page arguments which are extracted from the page's default constructor. Think of them as string path segments on steroid.


### PR DESCRIPTION
Greetings,

Recently tried the guide to implement this amazing library and got confused in the 'Finalize the setup' section, thought AutoRouterDelegeate was a class I had to implement, but figured out that it was a class from the library.

Details: 
- changed AutoRouterDelegeate to AutoRouterDelegate
- changed parameter named _appDelegate to _appRouter
- add space before brackets