### PR TITLE
Repair function routerReportsNewRouteInformation parameter type 

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_router_delegate.dart
+++ b/auto_route/lib/src/router/widgets/auto_router_delegate.dart
@@ -38,10 +38,13 @@ class AutoRouterDelegate extends RouterDelegate<UrlState> with ChangeNotifier {
   }
 
   static reportUrlChanged(BuildContext context, String url) {
-    Router.of(context).routeInformationProvider?.routerReportsNewRouteInformation(
-          RouteInformation(
+    Router.of(context)
+        .routeInformationProvider
+        ?.routerReportsNewRouteInformation(
+           RouteInformation(
             location: url,
           ),
+          type: RouteInformationReportingType.navigate,
         );
   }
 
@@ -165,7 +168,8 @@ class _DeclarativeAutoRouterDelegate extends AutoRouterDelegate {
     String? navRestorationScopeId,
     this.onPopRoute,
     this.onNavigate,
-    NavigatorObserversBuilder navigatorObservers = AutoRouterDelegate.defaultNavigatorObserversBuilder,
+    NavigatorObserversBuilder navigatorObservers =
+        AutoRouterDelegate.defaultNavigatorObserversBuilder,
   }) : super(
           controller,
           navRestorationScopeId: navRestorationScopeId,


### PR DESCRIPTION
Repair function routerReportsNewRouteInformation parameter type is needed in the new version flutter.