### PR TITLE
fix(generator): Bool opt type as num

### DIFF
--- a/auto_route_generator/lib/src/models/route_parameter_config.dart
+++ b/auto_route_generator/lib/src/models/route_parameter_config.dart
@@ -66,7 +66,7 @@ class ParamConfig {
       case 'num':
         return type.isNullable ? 'optNum' : 'getNum';
       case 'bool':
-        return type.isNullable ? 'optNum' : 'getBool';
+        return type.isNullable ? 'optBool' : 'getBool';
       default:
         return 'get';
     }


### PR DESCRIPTION
@Milad-Akarie 
The args class is being generated with optNum function when the value is bool