### PR TITLE
fix: Update to conform new API in Flutter 2.6

### DIFF
--- a/auto_route/lib/src/router/controller/auto_router_delegate.dart
+++ b/auto_route/lib/src/router/controller/auto_router_delegate.dart
@@ -27,6 +27,7 @@ class AutoRouterDelegate extends RouterDelegate<UrlState> with ChangeNotifier {
           RouteInformation(
             location: url,
           ),
+          type: RouteInformationReportingType.navigate,
         );
   }
 

--- a/auto_route/lib/src/router/provider/auto_route_information_provider.dart
+++ b/auto_route/lib/src/router/provider/auto_route_information_provider.dart
@@ -26,7 +26,7 @@ class AutoRouteInformationProvider extends RouteInformationProvider
 
   @override
   void routerReportsNewRouteInformation(RouteInformation routeInformation,
-      {bool isNavigation = true}) {
+      {required RouteInformationReportingType type}) {
     var replace = false;
     if (routeInformation is AutoRouteInformation) {
       replace = routeInformation.replace;
@@ -35,7 +35,7 @@ class AutoRouteInformationProvider extends RouteInformationProvider
     SystemNavigator.routeInformationUpdated(
       location: routeInformation.location!,
       state: routeInformation.state,
-      replace: replace || !isNavigation,
+      replace: replace || type != RouteInformationReportingType.navigate,
     );
     _value = routeInformation;
   }


### PR DESCRIPTION
This is a breaking change for users prior to Flutter 2.6. Can we have a prerelease on pub.dev?