### PR TITLE
fix: README.md code block start

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,16 +350,17 @@ What if want to show one of the child pages at `/dashboard`? we can simply do th
       ],      
     ),      
 ```      
-or by using a `RedirectRoute` ```dart      
-AutoRoute(      
-path: '/dashboard',      
-page: UserPage,      
-children: [      
-RedirectRoute(path: '', redirectTo: 'users'),      
-AutoRoute(path: 'users', page: UsersPage),      
-AutoRoute(path: 'posts', page: PostsPage),       
-],      
-),
+or by using a `RedirectRoute` 
+```dart      
+   AutoRoute(
+      path: '/dashboard',
+      page: UserPage,
+      children: [
+        RedirectRoute(path: '', redirectTo: 'users'),
+        AutoRoute(path: 'users', page: UsersPage),
+        AutoRoute(path: 'posts', page: PostsPage),
+     ],
+   ),
 ```      
 which can be simplified to the following where auto_route generates the redirect code for you.  
 ```dart      


### PR DESCRIPTION
the current release has a broken welcome page on pub.dev:

![image](https://user-images.githubusercontent.com/6349682/138103622-ec245577-a35b-482a-b1bb-4d88a2ef6d84.png)
