### PR TITLE
Fixed issue causing pendingChildren to become immutable

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -72,7 +72,7 @@ abstract class RoutingController with ChangeNotifier {
   RouteData _createRouteData(RouteMatch route, RouteData parent) {
     final mayUpdateController = childControllers[route.key];
 
-    var pendingChildren = const <RouteMatch>[];
+    var pendingChildren = <RouteMatch>[];
     if (mayUpdateController == null && route.hasChildren) {
       pendingChildren = route.children!;
     }


### PR DESCRIPTION
Since the list is `const` it is implicitly immutable due to being a compile time constant.  Removed the const which fixed the issue  described here https://github.com/Milad-Akarie/auto_route_library/issues/822