### PR TITLE
Animation controller should be disposed

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -160,6 +160,7 @@ class AutoTabsRouterState extends State<AutoTabsRouter>
 
   @override
   void dispose() {
+    _animationController.dispose();
     super.dispose();
     if (_controller != null) {
       _controller!.dispose();


### PR DESCRIPTION
You can read about it here: https://stackoverflow.com/questions/58802223/flutter-ticker-must-be-disposed-before-calling-super-dispose

Stumbled upon it in a project of mine, when page that used AutoTabsScaffold got a build depending on some provider that have changed;

<img width="1486" alt="Screenshot 2021-12-13 at 23 39 44" src="https://user-images.githubusercontent.com/1188349/145886815-47d827e8-c1ca-497d-bf8c-e490b3213dba.png">