### PR TITLE
added placeholder to nested autoRouter

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_router.dart
@@ -13,6 +13,7 @@ class AutoRouter extends StatefulWidget {
   final String? navRestorationScopeId;
   final bool inheritNavigatorObservers;
   final GlobalKey<NavigatorState>? navigatorKey;
+  final WidgetBuilder? placeholder;
 
   const AutoRouter({
     Key? key,
@@ -22,6 +23,7 @@ class AutoRouter extends StatefulWidget {
     this.navRestorationScopeId,
     this.navigatorKey,
     this.inheritNavigatorObservers = true,
+    this.placeholder,
   }) : super(key: key);
 
   static Widget declarative({
@@ -34,6 +36,7 @@ class AutoRouter extends StatefulWidget {
     bool inheritNavigatorObservers = true,
     GlobalKey<NavigatorState>? navigatorKey,
     OnNestedNavigateCallBack? onNavigate,
+    WidgetBuilder? placeholder,
   }) =>
       _DeclarativeAutoRouter(
         onPopRoute: onPopRoute,
@@ -41,6 +44,7 @@ class AutoRouter extends StatefulWidget {
         navRestorationScopeId: navRestorationScopeId,
         navigatorObservers: navigatorObservers,
         onNavigate: onNavigate,
+        placeholder: placeholder,
         routes: routes,
       );
 
@@ -120,6 +124,7 @@ class AutoRouterState extends State<AutoRouter> {
       router: _controller!,
       navRestorationScopeId: widget.navRestorationScopeId,
       navigatorObservers: _navigatorObservers,
+      placeholder: widget.placeholder,
     );
     final stateHash = controller!.stateHash;
     return RouterScope(
@@ -162,6 +167,7 @@ class _DeclarativeAutoRouter extends StatefulWidget {
   final bool inheritNavigatorObservers;
   final GlobalKey<NavigatorState>? navigatorKey;
   final OnNestedNavigateCallBack? onNavigate;
+  final WidgetBuilder? placeholder;
 
   const _DeclarativeAutoRouter({
     Key? key,
@@ -173,6 +179,7 @@ class _DeclarativeAutoRouter extends StatefulWidget {
     this.navRestorationScopeId,
     this.inheritNavigatorObservers = true,
     this.onNavigate,
+    this.placeholder,
   }) : super(key: key);
 
   @override
@@ -248,6 +255,7 @@ class _DeclarativeAutoRouterState extends State<_DeclarativeAutoRouter> {
           navRestorationScopeId: widget.navRestorationScopeId,
           navigatorObservers: _navigatorObservers,
           didPop: widget.onPopRoute,
+          placeholder: widget.placeholder,
         ),
       ),
     );


### PR DESCRIPTION
Thanks for the amazing package!!

Was getting a flash white screen for a split second, this is solved with a `placeholder` in the `routerDelegate`, but the sub-routes don't have a delegate. So I have added a placeholder to the `AutoRouter` widget, I have tested it and it works as intended. 

Might be related to: https://github.com/Milad-Akarie/auto_route_library/issues/619