### PR TITLE
extended message for duplicate route name

### DIFF
--- a/auto_route_generator/lib/src/code_builder/library_builder.dart
+++ b/auto_route_generator/lib/src/code_builder/library_builder.dart
@@ -40,7 +40,7 @@ String generateLibrary(RouterConfig config, {bool usesPartBuilder = false}) {
     throwIf(
       (checkedRoutes.any((r) =>
           r.routeName == route.routeName && r.pathName != route.pathName)),
-      'Duplicate route names must have the same path! [${route.name}]\nNote: Unless specified, route name is generated from page name.',
+      'Duplicate route names must have the same path! (name: ${route.name}, path: ${route.pathName})\nNote: Unless specified, route name is generated from page name.',
       element: config.element,
     );
     checkedRoutes.add(route);


### PR DESCRIPTION
just adding more information to the duplication route exception

before
```
Duplicate route names must have the same path! [null]
Note: Unless specified, route name is generated from page name.
```

after
```
Duplicate route names must have the same path! (name: null, path: /some/path)
Note: Unless specified, route name is generated from page name.
```