### PR TITLE
fix PageTransitionsTheme ignored on iOS

### DIFF
--- a/auto_route/lib/src/router/auto_route_page.dart
+++ b/auto_route/lib/src/router/auto_route_page.dart
@@ -337,10 +337,7 @@ class AdaptivePage<T> extends _TitledAutoRoutePage<T> {
     if (kIsWeb) {
       return _NoAnimationPageRouteBuilder<T>(page: this);
     }
-    final platform = Theme.of(context).platform;
-    if (platform == TargetPlatform.iOS || platform == TargetPlatform.macOS) {
-      return _PageBasedCupertinoPageRoute<T>(page: this);
-    }
+
     return PageBasedMaterialPageRoute<T>(page: this);
   }
 }


### PR DESCRIPTION
When using `AdaptiveRoute` on Android everything works as expected but on iOS custom `PageTransitionsTheme` is ignored. 

```
PageTransitionsTheme(
  builders: {
    TargetPlatform.android: CustomAndroidTransitionsBuilder(), // not ignored on Android device 
    TargetPlatform.iOS: CustomiOSTransitionsBuilder(), // ignored on iOS device
  },
)
```

The reason is that `_PageBasedCupertinoPageRoute` never uses `PageTransitionsTheme`:

```
... _PageBasedCupertinoPageRoute

@override
Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
  return buildPageTransitions<T>(this, context, animation, secondaryAnimation, child);
}

... PageBasedMaterialPageRoute

@override
Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
  final PageTransitionsTheme theme = Theme.of(context).pageTransitionsTheme;
  return theme.buildTransitions<T>(this, context, animation, secondaryAnimation, child);
}
```

As `PageBasedMaterialPageRoute` does automatically support switching between Android/iOS page transitions these 3 lines can be removed and everything continues working as before and in case `PageTransitionsTheme` has custom transitions for iOS they're supported too.
