### PR TITLE
Update build.yaml

### DIFF
--- a/auto_route_generator/build.yaml
+++ b/auto_route_generator/build.yaml
@@ -3,6 +3,5 @@ builders:
     import: "package:auto_route_generator/builder.dart"
     builder_factories: ["autoRouteGenerator"]
     build_extensions: {'.dart': ['.gr.dart']}
-    required_inputs: ['.g.dart']
     auto_apply: dependents
     build_to: source


### PR DESCRIPTION
`required_inputs: ['.g.dart']` will effect many package generation be changed to `.gr.dart` or disappear.
And all code don't use required_inputs to generation any other part. So I suppose remove this line, it can't work with hive package.