### PR TITLE
Animation controller from AutoTabsRouter should be disposed

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -203,6 +203,12 @@ class _AutoTabsRouterIndexedStackState extends _AutoTabsRouterState
   }
 
   @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
   void _setupController() {
     assert(_controller != null);
     _controller!.setupRoutes(widget.routes);


### PR DESCRIPTION
Not disposed AnimationController leaks potentially a Ticker, more about it here: https://stackoverflow.com/questions/58802223/flutter-ticker-must-be-disposed-before-calling-super-dispose

PR fixes the following problem:
```
════════ Exception caught by widgets library ═══════════════════════════════════
The following assertion was thrown while finalizing the widget tree:
AutoTabsRouterState#6d120(ticker active) was disposed with an active Ticker.

AutoTabsRouterState created a Ticker via its SingleTickerProviderStateMixin, but at the time dispose() was called on the mixin, that Ticker was still active. The Ticker must be disposed before calling super.dispose().

Tickers used by AnimationControllers should be disposed by calling dispose() on the AnimationController itself. Otherwise, the ticker will leak.

The offending ticker was: Ticker(created by AutoTabsRouterState#6d120)
The stack trace when the Ticker was actually created was:
#0      new Ticker.<anonymous closure>
package:flutter/…/scheduler/ticker.dart:67
#1      new Ticker
package:flutter/…/scheduler/ticker.dart:69
#2      SingleTickerProviderStateMixin.createTicker
package:flutter/…/widgets/ticker_provider.dart:198
#3      new AnimationController
package:flutter/…/animation/animation_controller.dart:246
#4      AutoTabsRouterState.initState
package:auto_route/…/widgets/auto_tabs_router.dart:90
#5      StatefulElement._firstBuild
package:flutter/…/widgets/framework.dart:4893
#6      ComponentElement.mount
package:flutter/…/widgets/framework.dart:4729
...     Normal element mounting (166 frames)
#172    Element.inflateWidget
package:flutter/…/widgets/framework.dart:3790
#173    MultiChildRenderObjectElement.inflateWidget
package:flutter/…/widgets/framework.dart:6422
#174    MultiChildRenderObjectElement.mount
package:flutter/…/widgets/framework.dart:6433
...     Normal element mounting (197 frames)
#371    Element.inflateWidget
package:flutter/…/widgets/framework.dart:3790
#372    Element.updateChild
package:flutter/…/widgets/framework.dart:3524
#373    ComponentElement.performRebuild
package:flutter/…/widgets/framework.dart:4780
#374    StatefulElement.performRebuild
package:flutter/…/widgets/framework.dart:4928
#375    Element.rebuild
package:flutter/…/widgets/framework.dart:4477
#376    BuildOwner.buildScope
package:flutter/…/widgets/framework.dart:2659
#377    WidgetsBinding.drawFrame
package:flutter/…/widgets/binding.dart:882
#378    RendererBinding._handlePersistentFrameCallback
package:flutter/…/rendering/binding.dart:363
#379    SchedulerBinding._invokeFrameCallback
package:flutter/…/scheduler/binding.dart:1144
#380    SchedulerBinding.handleDrawFrame
package:flutter/…/scheduler/binding.dart:1081
#381    SchedulerBinding.scheduleWarmUpFrame.<anonymous closure>
package:flutter/…/scheduler/binding.dart:862
(elided 11 frames from class _RawReceivePortImpl, class _Timer, dart:async, and dart:async-patch)
```