### PR TITLE
add *.gr.dart to gitignore

### DIFF
--- a/auto_route/example/.gitignore
+++ b/auto_route/example/.gitignore
@@ -70,3 +70,6 @@
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+#auto generated files
+*.gr.dart


### PR DESCRIPTION
I think this file is making repo so dirty on commits and should be ignored and generated every time.
this would be helpful if you can add it to the docs