### PR TITLE
Added physics parameter to `AutoTabsRouter`

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -17,6 +17,7 @@ abstract class AutoTabsRouter extends StatefulWidget {
   final List<PageRouteInfo> routes;
   final NavigatorObserversBuilder navigatorObservers;
   final bool inheritNavigatorObservers;
+  final ScrollPhysics? physics;
 
   // if activeIndex != homeIndex
   // set activeIndex to homeIndex
@@ -28,6 +29,7 @@ abstract class AutoTabsRouter extends StatefulWidget {
     required this.routes,
     this.homeIndex = -1,
     this.inheritNavigatorObservers = true,
+    this.physics,
     this.navigatorObservers =
         AutoRouterDelegate.defaultNavigatorObserversBuilder,
   }) : super(key: key);
@@ -52,6 +54,7 @@ abstract class AutoTabsRouter extends StatefulWidget {
     bool animatePageTransition,
     Duration duration,
     Curve curve,
+    ScrollPhysics? physics,
     bool inheritNavigatorObservers,
     NavigatorObserversBuilder navigatorObservers,
   }) = _AutoTabsRouterPageView;
@@ -63,6 +66,7 @@ abstract class AutoTabsRouter extends StatefulWidget {
     int homeIndex,
     Duration? duration,
     Curve curve,
+    ScrollPhysics? physics,
     bool inheritNavigatorObservers,
     NavigatorObserversBuilder navigatorObservers,
   }) = _AutoTabsRouterTabBar;
@@ -387,12 +391,14 @@ class _AutoTabsRouterPageView extends AutoTabsRouter {
     this.duration = kTabScrollDuration,
     this.curve = Curves.easeInOut,
     bool inheritNavigatorObservers = true,
+    ScrollPhysics? physics,
     NavigatorObserversBuilder navigatorObservers =
         AutoRouterDelegate.defaultNavigatorObserversBuilder,
   })  : _pageViewModeBuilder = builder,
         super._(
           key: key,
           routes: routes,
+          physics: physics,
           homeIndex: homeIndex,
           navigatorObservers: navigatorObservers,
           inheritNavigatorObservers: inheritNavigatorObservers,
@@ -468,6 +474,7 @@ class AutoTabsRouterPageViewState extends _AutoTabsRouterState
             context,
             PageView.builder(
               controller: _pageController,
+              physics: widget.physics,
               itemCount: stack.length,
               onPageChanged: _controller!.setActiveIndex,
               itemBuilder: (context, index) {
@@ -515,12 +522,14 @@ class _AutoTabsRouterTabBar extends AutoTabsRouter {
     int homeIndex = -1,
     this.duration,
     this.curve = Curves.ease,
+    ScrollPhysics? physics,
     bool inheritNavigatorObservers = true,
     NavigatorObserversBuilder navigatorObservers =
         AutoRouterDelegate.defaultNavigatorObserversBuilder,
   }) : super._(
           key: key,
           routes: routes,
+          physics: physics,
           homeIndex: homeIndex,
           navigatorObservers: navigatorObservers,
           inheritNavigatorObservers: inheritNavigatorObservers,
@@ -599,6 +608,7 @@ class _AutoTabsRouterTabBarState extends _AutoTabsRouterState
           return builder(
             context,
             CustomTabBarView(
+              physics: widget.physics,
               controller: _tabController,
               children: List.generate(
                 stack.length,

--- a/auto_route/pubspec.yaml
+++ b/auto_route/pubspec.yaml
@@ -15,14 +15,12 @@ dependencies:
   meta: ^1.7.0
   universal_html: ^2.0.8
 
-
-
 dev_dependencies:
   build_runner:
   auto_route_generator:
-    path: ../auto_route_generator
+    git:
+      url: https://github.com/kishan-dhankecha/auto_route_library
+      path: auto_route_generator/
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.4
-
-

--- a/auto_route/pubspec.yaml
+++ b/auto_route/pubspec.yaml
@@ -1,7 +1,8 @@
 name: auto_route
 description: AutoRoute is a declarative routing solution, where everything needed for navigation is automatically generated for you.
 version: 4.0.1
-homepage: https://github.com/Milad-Akarie/auto_route_library
+
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -16,7 +16,9 @@ dependencies:
   code_builder: ^4.1.0
   dart_style: ^2.2.0
   auto_route:
-    path: ../auto_route
+    git:
+      url: https://github.com/kishan-dhankecha/auto_route_library
+      path: auto_route/
 
 
 dev_dependencies:

--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -1,7 +1,8 @@
 name: auto_route_generator
 description: AutoRoute is a declartive routing solution, where everything needed for navigation is automatically generated for you.
 version: 4.0.0
-homepage: https://github.com/Milad-Akarie/auto_route_library
+
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -15,8 +15,7 @@ dependencies:
   code_builder: ^4.1.0
   dart_style: ^2.2.0
   auto_route:
-       ^4.0.0
-#    path: ../auto_route
+    path: ../auto_route
 
 
 dev_dependencies:


### PR DESCRIPTION
### Solves issue
#1109 

### solution
- Added `physics` as optional parameter to `AutoTabsRouter`

### Use example
- pageView

```dart
AutoTabsRouter.pageView(
  routes: routes,
  physics: const NeverScrollableScrollPhysics(),
  builder: (context, child, _) {
    ...
  },
);
```

- tabBar

```dart
AutoTabsRouter.tabBar(
  routes: routes,
  physics: const NeverScrollableScrollPhysics(),
  builder: (context, child, _) {
    ...
  },
);
```