### PR TITLE
Adds compatibility lock

### DIFF
--- a/auto_route/pubspec.yaml
+++ b/auto_route/pubspec.yaml
@@ -4,7 +4,7 @@ version: 4.0.1
 homepage: https://github.com/Milad-Akarie/auto_route_library
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This auto_route version won't work on the SDK lower from 2.17.x because of

```
../../.pub-cache/hosted/pub.dartlang.org/auto_route-4.0.1/lib/src/router/provider/auto_route_information_provider.dart:20:47: Error: Property 'window' cannot be accessed on 'WidgetsBinding?' because it is potentially null.
 - 'WidgetsBinding' is from 'package:flutter/src/widgets/binding.dart' ('../../fvm/versions/2.10.5/packages/flutter/lib/src/widgets/binding.dart').
Try accessing using ?. instead.
            location: WidgetsBinding.instance.window.defaultRouteName);
```