### PR TITLE
Fix animation controller dispose

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -198,10 +198,10 @@ class _AutoTabsRouterIndexedStackState extends _AutoTabsRouterState with SingleT
     _tabsHash = const ListEquality().hash(widget.routes);
   }
 
-   @override
+  @override
   void dispose() {
-    super.dispose();
     _animationController.dispose();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
This is a continuation from https://github.com/Milad-Akarie/auto_route_library/pull/1093.

The order of invocations inside dispose() method is critical because `super.dispose()` validates that all AnimationControllers have been disposed. Therefore we first must dispose the animation controller, then call `super.dispose()`.

The official documentation suggests to call `super.dispose()` as the last invocation when overriding the `dispose()` method.

_Implementations of this method should end with a call to the inherited method, as in super.dispose()._ [Source](https://api.flutter.dev/flutter/widgets/State/dispose.html)
