### PR TITLE
Fix "Router class name must be prefixed with $" error when using part builder

### DIFF
--- a/auto_route_generator/lib/auto_route_generator.dart
+++ b/auto_route_generator/lib/auto_route_generator.dart
@@ -72,8 +72,8 @@ class AutoRouteGenerator extends Generator {
       '.gr.dart',
     );
 
-    final hasPart = clazz.library.parts.any(
-      (e) => e.uri?.endsWith(part) ?? false,
+    final hasPart = clazz.library.parts2.any(
+      (e) => e.toString().endsWith(part) ?? false,
     );
     return hasPart;
   }

--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   build: ^2.1.1
   source_gen: ^1.1.1
-  analyzer: ">=2.7.0 <4.4.0"
+  analyzer: ">=4.3.0 <4.4.0"
   path: ^1.8.0
   build_runner: ^2.1.5
   code_builder: ^4.1.0


### PR DESCRIPTION
### The problem
[Setup And Usage](https://pub.dev/packages/auto_route#setup-and-usage) section of the documentation contains two examples. While the example with `$AppRouter`:
```dart
@MaterialAutoRouter(              
  replaceInRouteName: 'Page,Route',              
  routes: <AutoRoute>[              
    AutoRoute(page: BookListPage, initial: true),              
    AutoRoute(page: BookDetailsPage),              
  ],              
)              
class $AppRouter {}              
```
works, another example which using `part` file:
```dart
part 'app_router.gr.dart';      
        
@MaterialAutoRouter(              
  replaceInRouteName: 'Page,Route',              
  routes: <AutoRoute>[              
    AutoRoute(page: BookListPage, initial: true),              
    AutoRoute(page: BookDetailsPage),              
  ],              
)                   
class AppRouter extends _$AppRouter{} 
```
refuses to generate code with 
```sh
[SEVERE] auto_route_generator:autoRouteGenerator on lib/navigation/app_router.dart:

Router class name must be prefixed with $
package:space_flight_news/navigation/app_router.dart:15:7
   ╷
15 │ class AppRouter extends _$AppRouter {}
   │       ^^^^^^^^^
   ╵
```
It is reproducible with an ordinary empty Flutter project containing:
```yaml

environment:
  sdk: '>=2.17.6 <3.0.0'
  flutter: '>=3.0.5'

dependencies:
  auto_route: 4.2.1
  flutter:
    sdk: flutter

dev_dependencies:
  auto_route_generator: 4.2.0
  build_runner: 2.2.0
```

### The reason
`RouterConfigResolver.resolve` is being called with `usesPartBuilder = false`, because `AutoRouteGenerator._hasPartDirective` returns `false` even for a file that does contain `part` directive. The reason is that it uses `.parts`:
```dart
    final hasPart = clazz.library.parts.any(
      (e) => e.uri?.endsWith(part) ?? false,
    );
    return hasPart;
```
which are deprecated since [analyzer](https://pub.dev/packages/analyzer/changelog#430) v `4.3.0` and are always empty. From  `.../.pub-cache/hosted/pub.dartlang.org/analyzer-4.3.0/lib/dart/element/element.dart` source code:
```dart  /// Return a list containing all of the compilation units that are included in
  /// this library using a `part` directive. This does not include the defining
  /// compilation unit that contains the `part` directives.
  @Deprecated('Use parts2 instead')
  List<CompilationUnitElement> get parts;

  /// Returns the list of `part` directives of this library.
  List<PartElement> get parts2;
```

### The fix
This PR uses the new `.parts2` property and updates `analyzer` dependency to the version where `.parts` were deprecated.