### PR TITLE
Updating auto_route_generator to use parts2 instead of parts

### DIFF
--- a/auto_route_generator/lib/auto_route_generator.dart
+++ b/auto_route_generator/lib/auto_route_generator.dart
@@ -72,8 +72,10 @@ class AutoRouteGenerator extends Generator {
       '.gr.dart',
     );
 
-    final hasPart = clazz.library.parts.any(
-      (e) => e.uri?.endsWith(part) ?? false,
+    final hasPart = clazz.library.parts2
+        .map((e) => e.uri)
+        .whereType<DirectiveUriWithRelativeUriString>()
+        .any((e) => e.relativeUriString.endsWith(part)
     );
     return hasPart;
   }

--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   build: ^2.1.1
   source_gen: ^1.1.1
-  analyzer: ">=2.7.0 <4.4.0"
+  analyzer: ">=4.3.0 <4.4.0"
   path: ^1.8.0
   build_runner: ^2.1.5
   code_builder: ^4.1.0


### PR DESCRIPTION
Like the title says. The current code that uses `parts` is broken with `analyzer` version `4.3.0` or newer. Realistically the issue should be fixed upstream since this seems like a bug in `analyzer`, but they are deprecating the `parts` field so it might be a good idea to migrate away from it anyway.

Fixes #1172 