### PR TITLE
Upgrade analyzer package to version 4.3.0 AND above

### DIFF
--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_route_generator
 description: AutoRoute is a declartive routing solution, where everything needed for navigation is automatically generated for you.
-version: 5.0.0
+version: 5.0.1
 homepage: https://github.com/Milad-Akarie/auto_route_library
 
 environment:
@@ -9,7 +9,7 @@ environment:
 dependencies:
   build: ^2.1.1
   source_gen: ^1.1.1
-  analyzer: ">=4.3.0 <4.4.0"
+  analyzer: ^4.3.0
   path: ^1.8.0
   build_runner: ^2.1.5
   code_builder: ^4.1.0


### PR DESCRIPTION
Limiting the versioning for the analyzer package to `">=4.3.0 <4.4.0"` as before doesn't seem to have a reason and prevents the use of this package in combination with other packages (e.g. isar_flutter_libs 3.0.0-dev.12).
I couldn't test this yet since the generator_test package seems very outdated (correct me if I'm wrong) but `dart analyze` seemed ok. It would be great if, before merging, someone would quickly test if this works.
I also bumped the version of auto_route_generator to `5.0.1`.