### PR TITLE
add opaque property to AdaptiveRoute

### DIFF
--- a/auto_route/lib/src/common/auto_route_annotations.dart
+++ b/auto_route/lib/src/common/auto_route_annotations.dart
@@ -277,6 +277,12 @@ class CupertinoRoute<T> extends AutoRoute<T> {
 
 @optionalTypeArgs
 class AdaptiveRoute<T> extends AutoRoute<T> {
+  /// passed to the title property in [CupertinoPageRoute]
+  final String? cupertinoPageTitle;
+
+  /// passed to the opaque property in [_NoAnimationPageRouteBuilder] only when kIsWeb
+  final bool opaque;
+
   const AdaptiveRoute({
     bool initial = false,
     bool fullscreenDialog = false,
@@ -289,6 +295,7 @@ class AdaptiveRoute<T> extends AutoRoute<T> {
     required Type page,
     List<Type>? guards,
     List<AutoRoute>? children,
+    this.opaque = true,
     Map<String, dynamic> meta = const {},
     bool? deferredLoading,
   }) : super(
@@ -305,9 +312,6 @@ class AdaptiveRoute<T> extends AutoRoute<T> {
           meta: meta,
           deferredLoading: deferredLoading,
         );
-
-  /// passed to the title property in [CupertinoPageRoute]
-  final String? cupertinoPageTitle;
 }
 
 @optionalTypeArgs

--- a/auto_route/lib/src/router/auto_route_page.dart
+++ b/auto_route/lib/src/router/auto_route_page.dart
@@ -11,6 +11,7 @@ abstract class AutoRoutePage<T> extends Page<T> {
   final Widget _child;
   final bool fullscreenDialog;
   final bool maintainState;
+  final bool opaque;
 
   final _popCompleter = Completer<T?>();
 
@@ -21,6 +22,7 @@ abstract class AutoRoutePage<T> extends Page<T> {
     required Widget child,
     this.fullscreenDialog = false,
     this.maintainState = true,
+    this.opaque = true,
     LocalKey? key,
   })  : _child = child is AutoRouteWrapper
             ? WrappedRoute(
@@ -161,7 +163,7 @@ mixin _NoAnimationPageRouteTransitionMixin<T> on PageRoute<T> {
   String? get barrierLabel => null;
 
   @override
-  bool get opaque => true;
+  bool get opaque => _page.opaque;
 
   @override
   bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
@@ -270,11 +272,13 @@ abstract class _TitledAutoRoutePage<T> extends AutoRoutePage<T> {
     this.title,
     bool fullscreenDialog = false,
     bool maintainState = true,
+    bool opaque = true,
   }) : super(
           routeData: routeData,
           child: child,
           maintainState: maintainState,
           fullscreenDialog: fullscreenDialog,
+          opaque: opaque,
         );
 }
 
@@ -330,12 +334,14 @@ class AdaptivePage<T> extends _TitledAutoRoutePage<T> {
     String? title,
     bool fullscreenDialog = false,
     bool maintainState = true,
+    bool opaque = true,
   }) : super(
           routeData: routeData,
           child: child,
           title: title,
           maintainState: maintainState,
           fullscreenDialog: fullscreenDialog,
+          opaque: opaque,
         );
 
   @override

--- a/auto_route_generator/lib/src/code_builder/root_router_builder.dart
+++ b/auto_route_generator/lib/src/code_builder/root_router_builder.dart
@@ -147,8 +147,13 @@ Spec buildMethod(RouteConfig r, bool deferredLoading) {
                     'child': constructedPage,
                     if (r.maintainState == false) 'maintainState': literalBool(false),
                     if (r.fullscreenDialog == true) 'fullscreenDialog': literalBool(true),
-                    if ((r.routeType == RouteType.cupertino || r.routeType == RouteType.adaptive) && r.cupertinoNavTitle != null)
-                      'title': literalString(r.cupertinoNavTitle!),
+                    if (r.routeType == RouteType.cupertino) ...{
+                      if (r.cupertinoNavTitle != null) 'title': literalString(r.cupertinoNavTitle!),
+                    },
+                    if (r.routeType == RouteType.adaptive) ...{
+                      if (r.cupertinoNavTitle != null) 'title': literalString(r.cupertinoNavTitle!),
+                      if (r.customRouteOpaque != null) 'opaque': literalBool(r.customRouteOpaque!),
+                    },
                     if (r.routeType == RouteType.custom) ...{
                       if (r.customRouteBuilder != null) 'customRouteBuilder': r.customRouteBuilder!.refer,
                       if (r.transitionBuilder != null) 'transitionsBuilder': r.transitionBuilder!.refer,

--- a/auto_route_generator/lib/src/resolvers/route_config_resolver.dart
+++ b/auto_route_generator/lib/src/resolvers/route_config_resolver.dart
@@ -119,6 +119,7 @@ class RouteConfigResolver {
     } else if (autoRoute.instanceOf(TypeChecker.fromRuntime(AdaptiveRoute))) {
       routeType = RouteType.adaptive;
       cupertinoNavTitle = autoRoute.peek('cupertinoPageTitle')?.stringValue;
+      customRouteOpaque = autoRoute.peek('opaque')?.boolValue;
     } else if (autoRoute.instanceOf(TypeChecker.fromRuntime(CustomRoute))) {
       routeType = RouteType.custom;
       durationInMilliseconds =


### PR DESCRIPTION
This pull request adds availability to pass `opaque` property into `_NoAnimationPageRouteBuilder` when `AdaptiveRoute` is used for `kIsWeb`. Quite similar like `cupertinoPageTitle` which would only be used for iOS.

What do you think, should I rename `customRouteOpaque` to more generic like `routeOpaque`?