### PR TITLE
feat: Add a getter to expose child widget from AutoRoutePage

### DIFF
--- a/auto_route/lib/src/router/auto_route_page.dart
+++ b/auto_route/lib/src/router/auto_route_page.dart
@@ -16,6 +16,8 @@ abstract class AutoRoutePage<T> extends Page<T> {
 
   Future<T?> get popped => _popCompleter.future;
 
+  Widget get child => _child;
+
   AutoRoutePage({
     required this.routeData,
     required Widget child,


### PR DESCRIPTION
Thanks to that users will have the ability to access child widget from AutoRoutePage.

Fixes: https://github.com/Milad-Akarie/auto_route_library/issues/1137