### PR TITLE
feat: add SDK backward compatibility support

### DIFF
--- a/auto_route_generator/pubspec.yaml
+++ b/auto_route_generator/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.0.2
 homepage: https://github.com/Milad-Akarie/auto_route_library
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   build: ^2.1.1


### PR DESCRIPTION
It is important to support some old versions of Flutter as some projects are still using it for many different reasons. This PR adds support to dart `>=2.14.0`