### PR TITLE
fix: call didChangeTabRoute on AutoTabsRouter

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -568,6 +568,12 @@ class _AutoTabsRouterTabBarState extends _AutoTabsRouterState
       vsync: this,
     );
     _tabController.addListener(() {
+      if (_controller!.activeIndex != _tabController.index) {
+        _didChangeTabRoute(
+          _tabController.index,
+          _controller!.activeIndex,
+        );
+      }
       _controller!.setActiveIndex(_tabController.index);
     });
   }


### PR DESCRIPTION
**Problem**
The method `didChangeTabRoute` on the AutoRouterObserver is not being called when using `AutoTabsRouter.tabBar` in combination with a `TabBar` as described in #1246 .

**Reason**
The `_AutoTabsRouterTabBarState` listens to the `TabController`, which sets the TabsRouterController active index when the tab changes  `_controller!.setActiveIndex(_tabController.index)`.
This causes the TabsRouterController listener to be fired, however the following condition is not met and therefore didChangeTabRoute is not called `if (_controller!.activeIndex != _tabController.index)`.

**Solution**
Call `_didChangeTabRoute` inside the `TabController` listener as well.