### PR TITLE
don't skip auto route page pop listeners 

### DIFF
--- a/auto_route/lib/src/common/auto_route_observer.dart
+++ b/auto_route/lib/src/common/auto_route_observer.dart
@@ -131,7 +131,7 @@ class AutoRouteObserver extends AutoRouterObserver {
 
       final previousKey = (previousRoute!.settings as AutoRoutePage).routeKey;
       final List<AutoRouteAware>? previousSubscribers =
-      _listeners[previousKey]?.toList();
+        _listeners[previousKey]?.toList();
 
       if (previousSubscribers != null) {
         for (final AutoRouteAware routeAware in previousSubscribers) {

--- a/auto_route/lib/src/common/auto_route_observer.dart
+++ b/auto_route/lib/src/common/auto_route_observer.dart
@@ -127,19 +127,22 @@ class AutoRouteObserver extends AutoRouterObserver {
 
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    if (route.settings is AutoRoutePage &&
-        previousRoute?.settings is AutoRoutePage) {
+    if (previousRoute?.settings is AutoRoutePage) {
+
       final previousKey = (previousRoute!.settings as AutoRoutePage).routeKey;
       final List<AutoRouteAware>? previousSubscribers =
-          _listeners[previousKey]?.toList();
+      _listeners[previousKey]?.toList();
 
       if (previousSubscribers != null) {
         for (final AutoRouteAware routeAware in previousSubscribers) {
           routeAware.didPopNext();
         }
       }
-      final key = (route.settings as AutoRoutePage).routeKey;
+    }
 
+    if(route.settings is AutoRoutePage) {
+
+      final key = (route.settings as AutoRoutePage).routeKey;
       final List<AutoRouteAware>? subscribers = _listeners[key]?.toList();
 
       if (subscribers != null) {


### PR DESCRIPTION
prevents pop callbacks staying untriggered even if the other route (previous or current) is not an AutoRoutePage