### PR TITLE
feat: add coverage ignore file header

### DIFF
--- a/auto_route_generator/lib/builder.dart
+++ b/auto_route_generator/lib/builder.dart
@@ -7,7 +7,7 @@ Builder autoRouteGenerator(BuilderOptions options) {
   // gr stands for generated router.
   return LibraryBuilder(
     AutoRouteGenerator(),
-    header: '',
+    header: '// coverage:ignore-file',
     generatedExtension: '.gr.dart',
   );
 }


### PR DESCRIPTION
Same as #1357 but using `LibraryBuilder`s `header` option.