### PR TITLE
Allow unconstrained heights of an AutoTabRouter with a PageView

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_page_view.dart
+++ b/auto_route/lib/src/router/widgets/auto_page_view.dart
@@ -1,5 +1,6 @@
 /// Most of the code here is taking from flutter's [TabView]
 import 'package:auto_route/auto_route.dart';
+import 'package:expandable_page_view/expandable_page_view.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
@@ -135,7 +136,7 @@ class AutoPageViewState extends State<AutoPageView> {
   Widget build(BuildContext context) {
     return NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
-      child: PageView(
+      child: ExpandablePageView(
         scrollDirection: widget.scrollDirection,
         dragStartBehavior: widget.dragStartBehavior,
         controller: _controller,

--- a/auto_route/lib/src/router/widgets/auto_tab_view.dart
+++ b/auto_route/lib/src/router/widgets/auto_tab_view.dart
@@ -7,6 +7,7 @@
 /// and to set pageController.offset.round() to [TabController.index]
 /// so page is set when the scroll pos is rounded to it
 import 'package:auto_route/auto_route.dart';
+import 'package:expandable_page_view/expandable_page_view.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
@@ -194,7 +195,7 @@ class AutoTabViewState extends State<AutoTabView> {
     }());
     return NotificationListener<ScrollNotification>(
       onNotification: _handleScrollNotification,
-      child: PageView(
+      child: ExpandablePageView(
         scrollDirection: widget.scrollDirection,
         dragStartBehavior: widget.dragStartBehavior,
         controller: _pageController,

--- a/auto_route/pubspec.yaml
+++ b/auto_route/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   path: ^1.8.0
   collection: ^1.15.0
   meta: ^1.7.0
+  expandable_page_view: ^1.0.17
 
 
 dev_dependencies:


### PR DESCRIPTION
This leverages [`expandable_page_view`](https://pub.dev/packages/expandable_page_view) to allow having an AutoTabsRouter (using a `PageView`) inside a widget with an unbound height (i.e. a scrollable container).

I feel like this usecase is worth adding the extra dependency since it appears to be in good shape and, as a drop-in replacement for `PageView`, is easy to get rid of/replace again should it cause any pain in the future.