### PR TITLE
fix: fixed animation duration and jumpTo when animatePageTransition is false

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_page_view.dart
+++ b/auto_route/lib/src/router/widgets/auto_page_view.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 class AutoPageView extends StatefulWidget {
   const AutoPageView({
     Key? key,
+    required this.animatePageTransition,
+    this.duration = const Duration(milliseconds: 300),
     required this.controller,
     this.physics,
     required this.router,
@@ -13,6 +15,8 @@ class AutoPageView extends StatefulWidget {
     this.scrollDirection = Axis.horizontal,
   }) : super(key: key);
 
+  final bool animatePageTransition;
+  final Duration duration;
   final PageController controller;
   final Axis scrollDirection;
   final TabsRouter router;
@@ -83,17 +87,18 @@ class AutoPageViewState extends State<AutoPageView> {
   Future<void> _warpToCurrentIndex() async {
     if (!mounted) return Future<void>.value();
 
-    const Duration duration = Duration(milliseconds: 300);
+    final Duration duration = widget.duration;
+    final bool animatePageTransition = widget.animatePageTransition;
 
-    if (duration == Duration.zero) {
-      _controller.jumpToPage(_router.activeIndex);
-      return Future<void>.value();
-    }
     final int previousIndex = _router.previousIndex ?? 0;
     if ((_router.activeIndex - previousIndex).abs() == 1) {
       _warpUnderwayCount += 1;
-      await _controller.animateToPage(_router.activeIndex,
-          duration: duration, curve: Curves.ease);
+      if (animatePageTransition) {
+        await _controller.animateToPage(_router.activeIndex,
+            duration: duration, curve: Curves.ease);
+      } else {
+        _controller.jumpToPage(_router.activeIndex);
+      }
       _warpUnderwayCount -= 1;
       return Future<void>.value();
     }
@@ -111,8 +116,12 @@ class AutoPageViewState extends State<AutoPageView> {
     });
     _controller.jumpToPage(initialPage);
 
-    await _controller.animateToPage(_router.activeIndex,
-        duration: duration, curve: Curves.ease);
+    if (animatePageTransition) {
+      await _controller.animateToPage(_router.activeIndex,
+          duration: duration, curve: Curves.ease);
+    } else {
+      _controller.jumpToPage(_router.activeIndex);
+    }
     if (!mounted) return Future<void>.value();
     setState(() {
       _warpUnderwayCount -= 1;

--- a/auto_route/lib/src/router/widgets/auto_tab_view.dart
+++ b/auto_route/lib/src/router/widgets/auto_tab_view.dart
@@ -15,12 +15,15 @@ class AutoTabView extends StatefulWidget {
 
   const AutoTabView({
     Key? key,
+    required this.animatePageTransition,
     required this.controller,
     this.physics,
     required this.router,
     this.scrollDirection = Axis.horizontal,
     this.dragStartBehavior = DragStartBehavior.start,
   }) : super(key: key);
+
+  final bool animatePageTransition;
   final Axis scrollDirection;
   final TabController controller;
 
@@ -115,18 +118,18 @@ class AutoTabViewState extends State<AutoTabView> {
     }
 
     final Duration duration = _controller.animationDuration;
-
-    if (duration == Duration.zero) {
-      _pageController.jumpToPage(_currentIndex!);
-      return Future<void>.value();
-    }
+    final bool animatePageTransition = widget.animatePageTransition;
 
     final int previousIndex = _controller.previousIndex;
 
     if ((_currentIndex! - previousIndex).abs() == 1) {
       _warpUnderwayCount += 1;
-      await _pageController.animateToPage(_currentIndex!,
-          duration: duration, curve: Curves.ease);
+      if (animatePageTransition) {
+        await _pageController.animateToPage(_currentIndex!,
+            duration: duration, curve: Curves.ease);
+      } else {
+        _pageController.jumpToPage(_currentIndex!);
+      }
       _warpUnderwayCount -= 1;
       return Future<void>.value();
     }
@@ -144,8 +147,12 @@ class AutoTabViewState extends State<AutoTabView> {
     });
     _pageController.jumpToPage(initialPage);
 
-    await _pageController.animateToPage(_currentIndex!,
-        duration: duration, curve: Curves.ease);
+    if (animatePageTransition) {
+      await _pageController.animateToPage(_currentIndex!,
+          duration: duration, curve: Curves.ease);
+    } else {
+      _pageController.jumpToPage(_currentIndex!);
+    }
     if (!mounted) return Future<void>.value();
     setState(() {
       _warpUnderwayCount -= 1;

--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -69,6 +69,7 @@ abstract class AutoTabsRouter extends StatefulWidget {
     required List<PageRouteInfo> routes,
     AutoTabsTabBarBuilder? builder,
     int homeIndex,
+    bool animatePageTransition,
     Duration? duration,
     Axis scrollDirection,
     Curve curve,
@@ -498,6 +499,8 @@ class AutoTabsRouterPageViewState extends _AutoTabsRouterState
           return builder(
             context,
             AutoPageView(
+              animatePageTransition: typedWidget.animatePageTransition,
+              duration: typedWidget.duration,
               scrollDirection: typedWidget.scrollDirection,
               physics: typedWidget.physics,
               dragStartBehavior: typedWidget.dragStartBehavior,
@@ -525,6 +528,7 @@ class AutoTabsRouterPageViewState extends _AutoTabsRouterState
 
 class _AutoTabsRouterTabBar extends AutoTabsRouter {
   final AutoTabsTabBarBuilder? builder;
+  final bool animatePageTransition;
   final Duration? duration;
   final Curve curve;
   final ScrollPhysics? physics;
@@ -537,6 +541,7 @@ class _AutoTabsRouterTabBar extends AutoTabsRouter {
     this.scrollDirection = Axis.horizontal,
     this.builder,
     int homeIndex = -1,
+    this.animatePageTransition = true,
     this.duration,
     this.curve = Curves.ease,
     bool inheritNavigatorObservers = true,
@@ -586,6 +591,7 @@ class _AutoTabsRouterTabBarState extends _AutoTabsRouterState
 
   void _updateTabController() {
     _tabController = TabController(
+      animationDuration: typedWidget.duration,
       initialIndex: _controller!.activeIndex,
       length: _controller!.pageCount,
       vsync: this,
@@ -624,6 +630,7 @@ class _AutoTabsRouterTabBarState extends _AutoTabsRouterState
           return builder(
             context,
             AutoTabView(
+              animatePageTransition: typedWidget.animatePageTransition,
               scrollDirection: typedWidget.scrollDirection,
               physics: typedWidget.physics,
               dragStartBehavior: typedWidget.dragStartBehavior,


### PR DESCRIPTION
Changes that are similar to https://github.com/Milad-Akarie/auto_route_library/pull/1321 due to inactivity of that PR.