### PR TITLE
fix: delegate missing arguments in auto_route_guard redirect

### DIFF
--- a/auto_route/lib/src/router/controller/auto_route_guard.dart
+++ b/auto_route/lib/src/router/controller/auto_route_guard.dart
@@ -191,6 +191,8 @@ class NavigationResolver {
   }) async {
     return _router._redirect(
       route,
+      onFailure: onFailure,
+      replace: replace,
       onMatch: (scope, match) async {
         await _completer.future;
         scope.markUrlStateForReplace();


### PR DESCRIPTION
I was updating my project to use the latest auto_route and saw the new `redirect` functionality added since `7.2.3`, it seemed to work great except when you specifically want the redirected page to `replace` the current one. I saw the `replace` argument didn't change anything and by looking at the source code I saw it wasn't properly delegated.

Note: I did the same thing for the `onFailure` argument.