### PR TITLE
feat(auto_route): add `AutoPageRouteBuilder.opaque` argument

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -1000,6 +1000,7 @@ abstract class StackRouter extends RoutingController {
     RouteTransitionsBuilder? transitionBuilder,
     bool fullscreenDialog = false,
     Duration transitionDuration = const Duration(milliseconds: 300),
+    bool opaque = true,
   }) {
     final navigator = _navigatorKey.currentState;
     assert(navigator != null);
@@ -1009,6 +1010,7 @@ abstract class StackRouter extends RoutingController {
         fullscreenDialog: fullscreenDialog,
         transitionBuilder: transitionBuilder,
         transitionDuration: transitionDuration,
+        opaque: opaque,
       ),
     );
   }

--- a/auto_route/lib/src/router/transitions/custom_page_route.dart
+++ b/auto_route/lib/src/router/transitions/custom_page_route.dart
@@ -7,6 +7,7 @@ class AutoPageRouteBuilder<T> extends PageRoute<T> {
   AutoPageRouteBuilder({
     this.transitionBuilder,
     this.transitionDuration = const Duration(milliseconds: 300),
+    this.opaque = true,
     required this.child,
     bool fullscreenDialog = false,
   }) : super(fullscreenDialog: fullscreenDialog);
@@ -58,4 +59,7 @@ class AutoPageRouteBuilder<T> extends PageRoute<T> {
 
   @override
   final Duration transitionDuration;
+
+  @override
+  final bool opaque;
 }


### PR DESCRIPTION
Introduced new `opaque` argument in `AutoPageRouteBuilder`.
Allows the `opaque` argument to be used when calling `pushWidget()`.