### PR TITLE
fix: invalid pre v6 documetation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 
 ## Pre v6 documentation
 
-- [Pre v6 documentation](old/pre_v6_README.md)
+- [Pre v6 documentation](https://github.com/Milad-Akarie/auto_route_library/blob/master/old/pre_v6_README.md)
 
 ## Introduction
 


### PR DESCRIPTION
When in the pub.dev page, the link of pre-v6 documentation is invalid (Github shows the 404 page).
I fixed the issue by changing the link to the direct URL of the file in Github.