### PR TITLE
fix: crash if pendingChildren are passed in as unmodifiable list

### DIFF
--- a/auto_route/lib/src/route/route_data.dart
+++ b/auto_route/lib/src/route/route_data.dart
@@ -38,10 +38,11 @@ class RouteData {
     required this.router,
     RouteData? parent,
     required this.stackKey,
-    required this.pendingChildren,
+    required pendingChildren,
     required this.type,
   })  : _match = route,
-        _parent = parent;
+        _parent = parent,
+        pendingChildren = [...pendingChildren];
 
   /// Builds page title that's passed to [_PageBasedCupertinoPageRoute.title]
   /// where it can be used by [CupertinoNavigationBar]


### PR DESCRIPTION
### Problem

We are experiencing the following crash in our app:

```
0x0 UnmodifiableListMixin.clear (dart:_internal)
0x0 TabsRouter.setupRoutes + 694 (routing_controller.dart:694)
0x0 _AutoTabsRouterIndexedStackState._setupController + 290 (auto_tabs_router.dart:290)
0x0 AutoTabsRouterState.didChangeDependencies + 200 (auto_tabs_router.dart:200)
0x0 StatefulElement._firstBuild + 5237 (framework.dart:5237)
0x0 ComponentElement.mount + 5062 (framework.dart:5062)
```

Now the actual lines are a bit off, but as far as I can see the actual line causing the crash is in line 697 of the _routing_controller.dart_ `_routeData.pendingChildren.clear();` which also ties into the issue here #1641. 

### Cause of the error

This crash seems to happen sporadically, so I am struggling to reproduce it. However it is currently impacting our users pretty heavily (~20%). The issue seems to happen only after the app startup.

I did look through the codebase and the only issue I can see so far that would match the error is in line 69 of the _root_stack_router.dart_. Here the `pendingChildren` are passed in as a `const []` which would make it an unmodifiable list. The later `.clear()` call would therefore throw. (I do not know however why this only happens sporadically and not everytime)

_root_stack_router.dart_
```
  @override
  RouteData get routeData => RouteData(
        router: this,
        type: const RouteType.material(),
        stackKey: _stackKey,
        route: RouteMatch(
          config: DummyRootRoute('Root', path: ''),
          segments: const [''],
          stringMatch: '',
          key: const ValueKey('Root'),
        ),
        pendingChildren: const [],
      );
```

_routing_controller.dart_
```
  void setupRoutes(List<PageRouteInfo> routes) {
   //...

    if (routesToPush.isNotEmpty) {
      _pushAll(routesToPush);
    }
    _routeData.pendingChildren.clear();
  }

```

### Fix

I think there are multiple solutions

- Do not pass in a unmodifiable list
- Check if the list is empty before clearing it (proposed in #1641)
- Assure that pendingChildren are modifiable by creating a new list in the constructor

I chose option 3 as I think it makes the code more resilient toward the bug being reintroduced at a later point. We can now be sure that `pendingChildren` are always modifiable as we are creating a modifiable list inside `RouteData`.

