### PR TITLE
fix: ensure dynamic tab updates are handled in AutoTabsRouter.tabBar

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tab_view.dart
+++ b/auto_route/lib/src/router/widgets/auto_tab_view.dart
@@ -84,6 +84,11 @@ class AutoTabViewState extends State<AutoTabView> {
   void didUpdateWidget(AutoTabView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.controller != oldWidget.controller) {
+      oldWidget.controller.animation
+          ?.removeListener(_handleTabControllerAnimationTick);
+      _controller.animation?.addListener(_handleTabControllerAnimationTick);
+      _updateChildren();
+
       _currentIndex = _controller.index;
       _pageController.jumpToPage(_currentIndex!);
     }


### PR DESCRIPTION
Hi, 

The `AutoTabsRouter.tabBar` widget is not updating correctly when a new list of routes is passed to it.


| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/Milad-Akarie/auto_route_library/assets/105102312/02a7ee79-a6ba-4c14-ad5b-b3eff3f09b2d">  | <video src="https://github.com/Milad-Akarie/auto_route_library/assets/105102312/5685ab4e-acf1-4627-bbc0-abcc8507a9ac">|



Here is an example code to reproduce the problem :

```dart
void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  MyApp({super.key});

  final _appRouter = AppRouter();

  @override
  Widget build(BuildContext context) {
    return MaterialApp.router(
      debugShowCheckedModeBanner: false,
      routerConfig: _appRouter.config(),
    );
  }
}

@RoutePage()
class HomeScreen extends StatefulWidget {
  const HomeScreen({super.key});

  @override
  State<HomeScreen> createState() => _HomeScreenState();
}

class _HomeScreenState extends State<HomeScreen> {
  var tabs = ['First', 'Second', 'Third'];
  var routes = [
    const FirstTabRoute(),
    const SecondTabRoute(),
    const ThirdTabRoute(),
  ];

  @override
  void initState() {
    super.initState();

    Future.delayed(const Duration(seconds: 5), () {
      setState(() {
        tabs = [...tabs]..removeAt(0);
        routes = [...routes]..removeAt(0);
      });
    });
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: SafeArea(
        child: AutoTabsRouter.tabBar(
          routes: routes,
          builder: (context, child, tabController) {
            return Column(
              children: [
                TabBar(
                  tabs: _buildTabs(tabs),
                  controller: tabController,
                  onTap: context.tabsRouter.setActiveIndex,
                  isScrollable: true,
                  indicatorSize: TabBarIndicatorSize.tab,
                  labelColor: Colors.blue,
                ),
                Expanded(child: child),
              ],
            );
          },
        ),
      ),
    );
  }

  List<Widget> _buildTabs(List<String> tabs) {
    return tabs.map((tab) => Tab(text: tab, height: 46)).toList();
  }
}
```

router.dart


```dart
@AutoRouterConfig(
  replaceInRouteName: 'Page|Screen,Route',
)
class AppRouter extends $AppRouter {
  @override
  RouteType get defaultRouteType => const RouteType.adaptive();

  @override
  final List<AutoRoute> routes = [
    AutoRoute(
      path: '/',
      page: HomeRoute.page,
      children: [
        AutoRoute(
          initial: true,
          path: 'first',
          page: FirstTabRoute.page,
        ),
        AutoRoute(
          path: 'second',
          page: SecondTabRoute.page,
        ),
        AutoRoute(
          path: 'third',
          page: ThirdTabRoute.page,
        ),
      ],
    ),
  ];
}

```




