### PR TITLE
fix: keep TabsRouter.homeIndex in sync with AutoTabsRouter.homeIndex

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -611,7 +611,7 @@ class TabsRouter extends RoutingController {
   /// if activeIndex != homeIndex
   /// set activeIndex to homeIndex
   /// else pop parent
-  final int homeIndex;
+  int homeIndex;
 
   /// Default constructor
   TabsRouter(

--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -204,6 +204,14 @@ abstract class AutoTabsRouterState extends State<AutoTabsRouter> {
   void _setupController();
 
   @override
+  void didUpdateWidget(covariant AutoTabsRouter oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.homeIndex != oldWidget.homeIndex) {
+      _controller?.homeIndex = widget.homeIndex;
+    }
+  }
+
+  @override
   void dispose() {
     if (_controller != null) {
       _controller!.dispose();

--- a/auto_route/test/nested_tabs_router/tabs_router_tests.dart
+++ b/auto_route/test/nested_tabs_router/tabs_router_tests.dart
@@ -109,6 +109,9 @@ void runGeneralTests(String tabsType) {
       await tester.pumpAndSettle();
       expect(router.urlState.url, '/tab2');
 
+      await tester.tap(find.byTooltip('Change homeIndex'));
+      await tester.pump();
+
       final tabsRouter = router.innerRouterOf<TabsRouter>(TabsHostRoute.name);
       expect(tabsRouter, isNotNull);
       expect(await tabsRouter!.pop(), isTrue);

--- a/auto_route/test/nested_tabs_router/tabs_router_tests.dart
+++ b/auto_route/test/nested_tabs_router/tabs_router_tests.dart
@@ -102,6 +102,22 @@ void runGeneralTests(String tabsType) {
   );
 
   testWidgets(
+    'Attempting a pop when outside of the home tab should return to home tab',
+    (WidgetTester tester) async {
+      await pumpRouter(tester);
+      router.navigate(const Tab2Route());
+      await tester.pumpAndSettle();
+      expect(router.urlState.url, '/tab2');
+
+      final tabsRouter = router.innerRouterOf<TabsRouter>(TabsHostRoute.name);
+      expect(tabsRouter, isNotNull);
+      expect(await tabsRouter!.pop(), isTrue);
+      await tester.pumpAndSettle();
+      expect(router.urlState.url, '/');
+    },
+  );
+
+  testWidgets(
     'Initializing router App with deep-link "/tab3/tab3Nested2" should present FirstRoute/Tab3Route/Tab3Nested2Route',
     (WidgetTester tester) async {
       await pumpRouterApp(tester, router,

--- a/auto_route/test/test_page.dart
+++ b/auto_route/test/test_page.dart
@@ -134,38 +134,59 @@ class Tab3Nested2Page extends TestPage {
 }
 
 @RoutePage()
-class TabsHostPage extends StatelessWidget {
+class TabsHostPage extends StatefulWidget {
   final String tabsType;
 
   const TabsHostPage({Key? key, @queryParam this.tabsType = 'IndexedStack'})
       : super(key: key);
 
   @override
+  State<TabsHostPage> createState() => TabsHostPageState();
+}
+
+class TabsHostPageState extends State<TabsHostPage> {
+  int homeIndex = -1;
+
+  @override
   Widget build(BuildContext context) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          setState(() {
+            homeIndex = 0;
+          });
+        },
+        tooltip: 'Change homeIndex',
+      ),
+      body: Builder(builder: _buildRouter),
+    );
+  }
+
+  Widget _buildRouter(BuildContext context) {
     const routes = [
       Tab1Route(),
       Tab2Route(),
       Tab3Route(),
     ];
 
-    if (tabsType == 'IndexedStack') {
-      return const AutoTabsRouter(
+    if (widget.tabsType == 'IndexedStack') {
+      return AutoTabsRouter(
         routes: routes,
-        homeIndex: 0,
+        homeIndex: homeIndex,
       );
     }
 
-    if (tabsType == 'PageView') {
-      return const AutoTabsRouter.pageView(
+    if (widget.tabsType == 'PageView') {
+      return AutoTabsRouter.pageView(
         routes: routes,
-        homeIndex: 0,
+        homeIndex: homeIndex,
       );
     }
 
-    if (tabsType == 'TabBar') {
-      return const AutoTabsRouter.tabBar(
+    if (widget.tabsType == 'TabBar') {
+      return AutoTabsRouter.tabBar(
         routes: routes,
-        homeIndex: 0,
+        homeIndex: homeIndex,
       );
     }
 

--- a/auto_route/test/test_page.dart
+++ b/auto_route/test/test_page.dart
@@ -151,18 +151,21 @@ class TabsHostPage extends StatelessWidget {
     if (tabsType == 'IndexedStack') {
       return const AutoTabsRouter(
         routes: routes,
+        homeIndex: 0,
       );
     }
 
     if (tabsType == 'PageView') {
       return const AutoTabsRouter.pageView(
         routes: routes,
+        homeIndex: 0,
       );
     }
 
     if (tabsType == 'TabBar') {
       return const AutoTabsRouter.tabBar(
         routes: routes,
+        homeIndex: 0,
       );
     }
 


### PR DESCRIPTION
A fix for #1759. Also includes a general test for popping in the presence of a `homeIndex`.