### PR TITLE
feat: add back mixin to AutoRouteAware

### DIFF
--- a/auto_route/lib/src/common/auto_route_observer.dart
+++ b/auto_route/lib/src/common/auto_route_observer.dart
@@ -27,7 +27,7 @@ class AutoRouterObserver extends NavigatorObserver {
 
 /// An interface used to mark classes as AutoRouteAware entities
 /// usually implemented by widget States
-abstract class AutoRouteAware {
+abstract mixin class AutoRouteAware {
   /// Called when the top route has been popped off, and the current route
   /// shows up.
   void didPopNext() {}


### PR DESCRIPTION
Fixes #1734 

Dart 3 restricted the use of the `with` keyword for classes declared as `mixin class` or `mixin`. This PR changes AutoRouteAware from `abstract class AutoRouteAware` to `abstract mixin class AutoRouteAware`.
