### PR TITLE
fix: unable to get the label for back button(previous route title) and current route title on CupertinoNavigationBar and CupertinoSliverNavigationBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1563,25 +1563,6 @@ var isLoading = false;
   }      
 ```          
 
-### Remove shadow from nested routers
-
-This fixes the issue referenced here          
-https://stackoverflow.com/questions/53457772/why-there-is-a-shadow-between-nested-navigator          
-https://stackoverflow.com/questions/68986632/rid-of-elevation-of-nested-flutter-navigator-2-0
-
-```dart             
-MaterialApp.router(            
-  theme: ThemeData.dark().copyWith(            
-  pageTransitionsTheme: PageTransitionsTheme(            
-     builders: {            
-         // replace default CupertinoPageTransitionsBuilder with this          
-        TargetPlatform.iOS: NoShadowCupertinoPageTransitionsBuilder(),            
-        TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),            
-    } )          
-  ),          
- ```               
-
-**Note:** `CupertinoRoute` already uses this fix, so no need to override `PageTransitionsTheme`
 
 ## Migrating to v6
 

--- a/auto_route/example/lib/mobile/main.dart
+++ b/auto_route/example/lib/mobile/main.dart
@@ -1,4 +1,3 @@
-import 'package:auto_route/auto_route.dart';
 import 'package:example/data/db.dart';
 import 'package:example/mobile/router/auth_guard.dart';
 import 'package:example/mobile/router/router.dart';
@@ -22,12 +21,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       routerConfig: _rootRouter.config(),
-      theme: ThemeData.dark().copyWith(
-        pageTransitionsTheme: PageTransitionsTheme(builders: {
-          TargetPlatform.iOS: NoShadowCupertinoPageTransitionsBuilder(),
-          TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
-        }),
-      ),
+      theme: ThemeData.dark(),
       builder: (_, router) {
         return ChangeNotifierProvider<AuthService>(
           create: (_) => authService,

--- a/auto_route/lib/src/route/auto_route_config.dart
+++ b/auto_route/lib/src/route/auto_route_config.dart
@@ -33,7 +33,7 @@ class AutoRoute {
   final bool usesPathAsKey;
 
   /// a Map of dynamic data that can be accessed by
-  /// [RouteData.mete] when the route is created
+  /// [RouteData.meta] when the route is created
   final Map<String, dynamic> meta;
 
   /// Indicates what kind of [PageRoute] this route will use

--- a/auto_route/lib/src/router/auto_route_page.dart
+++ b/auto_route/lib/src/router/auto_route_page.dart
@@ -313,7 +313,9 @@ mixin _CustomPageRouteTransitionMixin<T> on PageRoute<T> {
 }
 
 class _PageBasedCupertinoPageRoute<T> extends PageRoute<T>
-    with CustomCupertinoRouteTransitionMixin<T> {
+    with
+        CupertinoRouteTransitionMixin<T>,
+        CupertinoRouteTransitionOverrideMixin<T> {
   _PageBasedCupertinoPageRoute({
     required AutoRoutePage<T> page,
     this.title,

--- a/auto_route/lib/src/router/widgets/custom_cupertino_transitions_builder.dart
+++ b/auto_route/lib/src/router/widgets/custom_cupertino_transitions_builder.dart
@@ -5,11 +5,11 @@
 // The adjustments made to this code is to disable unwanted shadow
 // of routes when used as nested routes, e.g inside of a TabsRouter
 
+import 'package:flutter/cupertino.dart'
+    show CupertinoDynamicColor, CupertinoRouteTransitionMixin;
+import 'package:flutter/foundation.dart';
 import 'dart:math';
 import 'dart:ui' show lerpDouble;
-
-import 'package:flutter/cupertino.dart' show CupertinoDynamicColor;
-import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -51,238 +51,6 @@ final Animatable<Offset> _kBottomUpTween = Tween<Offset>(
   end: Offset.zero,
 );
 
-/// A mixin that replaces the entire screen with an iOS transition for a
-/// [PageRoute].
-///
-/// {@template flutter.cupertino.cupertinoRouteTransitionMixin}
-/// The page slides in from the right and exits in reverse. The page also shifts
-/// to the left in parallax when another page enters to cover it.
-///
-/// The page slides in from the bottom and exits in reverse with no parallax
-/// effect for fullscreen dialogs.
-/// {@endtemplate}
-///
-/// See also:
-///
-///  * [MaterialRouteTransitionMixin], which is a mixin that provides
-///    platform-appropriate transitions for a [PageRoute].
-///  * [CupertinoPageRoute], which is a [PageRoute] that leverages this mixin.
-mixin CustomCupertinoRouteTransitionMixin<T> on PageRoute<T> {
-  /// Builds the primary contents of the route.
-  @protected
-  Widget buildContent(BuildContext context);
-
-  /// {@template flutter.cupertino.CupertinoRouteTransitionMixin.title}
-  /// A title string for this route.
-  ///
-  /// Used to auto-populate [CupertinoNavigationBar] and
-  /// [CupertinoSliverNavigationBar]'s `middle`/`largeTitle` widgets when
-  /// one is not manually supplied.
-  /// {@endtemplate}
-  String? get title;
-
-  ValueNotifier<String?>? _previousTitle;
-
-  /// The title string of the previous [CupertinoPageRoute].
-  ///
-  /// The [ValueListenable]'s value is readable after the route is installed
-  /// onto a [Navigator]. The [ValueListenable] will also notify its listeners
-  /// if the value changes (such as by replacing the previous route).
-  ///
-  /// The [ValueListenable] itself will be null before the route is installed.
-  /// Its content value will be null if the previous route has no title or
-  /// is not a [CupertinoPageRoute].
-  ///
-  /// See also:
-  ///
-  ///  * [ValueListenableBuilder], which can be used to listen and rebuild
-  ///    widgets based on a ValueListenable.
-  ValueListenable<String?> get previousTitle {
-    assert(
-      _previousTitle != null,
-      'Cannot read the previousTitle for a route that has not yet been installed',
-    );
-    return _previousTitle!;
-  }
-
-  @override
-  void didChangePrevious(Route<dynamic>? previousRoute) {
-    final String? previousTitleString =
-        previousRoute is CustomCupertinoRouteTransitionMixin
-            ? previousRoute.title
-            : null;
-    if (_previousTitle == null) {
-      _previousTitle = ValueNotifier<String?>(previousTitleString);
-    } else {
-      _previousTitle!.value = previousTitleString;
-    }
-    super.didChangePrevious(previousRoute);
-  }
-
-  @override
-  // A relatively rigorous eyeball estimation.
-  Duration get transitionDuration => const Duration(milliseconds: 400);
-
-  @override
-  Color? get barrierColor => null;
-
-  @override
-  String? get barrierLabel => null;
-
-  @override
-  bool canTransitionTo(TransitionRoute<dynamic> nextRoute) {
-    // Don't perform outgoing animation if the next route is a fullscreen dialog.
-    return nextRoute is CustomCupertinoRouteTransitionMixin &&
-        !nextRoute.fullscreenDialog;
-  }
-
-  /// True if an iOS-style back swipe pop gesture is currently underway for [route].
-  ///
-  /// This just check the route's [NavigatorState.userGestureInProgress].
-  ///
-  /// See also:
-  ///
-  ///  * [popGestureEnabled], which returns true if a user-triggered pop gesture
-  ///    would be allowed.
-  static bool isPopGestureInProgress(PageRoute<dynamic> route) {
-    return route.navigator!.userGestureInProgress;
-  }
-
-  /// True if an iOS-style back swipe pop gesture is currently underway for this route.
-  ///
-  /// See also:
-  ///
-  ///  * [isPopGestureInProgress], which returns true if a Cupertino pop gesture
-  ///    is currently underway for specific route.
-  ///  * [popGestureEnabled], which returns true if a user-triggered pop gesture
-  ///    would be allowed.
-  bool get popGestureInProgress => isPopGestureInProgress(this);
-
-  /// Whether a pop gesture can be started by the user.
-  ///
-  /// Returns true if the user can edge-swipe to a previous route.
-  ///
-  /// Returns false once [isPopGestureInProgress] is true, but
-  /// [isPopGestureInProgress] can only become true if [popGestureEnabled] was
-  /// true first.
-  ///
-  /// This should only be used between frames, not during build.
-  bool get popGestureEnabled => _isPopGestureEnabled(this);
-
-  static bool _isPopGestureEnabled<T>(PageRoute<T> route) {
-    // If there's nothing to go back to, then obviously we don't support
-    // the back gesture.
-    if (route.isFirst) return false;
-    // If the route wouldn't actually pop if we popped it, then the gesture
-    // would be really confusing (or would skip internal routes), so disallow it.
-    if (route.willHandlePopInternally) return false;
-    // Fullscreen dialogs aren't dismissible by back swipe.
-    if (route.fullscreenDialog) return false;
-    // If we're in an animation already, we cannot be manually swiped.
-    if (route.animation!.status != AnimationStatus.completed) return false;
-    // If we're being popped into, we also cannot be swiped until the pop above
-    // it completes. This translates to our secondary animation being
-    // dismissed.
-    if (route.secondaryAnimation!.status != AnimationStatus.dismissed) {
-      return false;
-    }
-    // If we're in a gesture already, we cannot start another.
-    if (isPopGestureInProgress(route)) return false;
-
-    // Looks like a back gesture would be welcome!
-    return true;
-  }
-
-  @override
-  RoutePopDisposition get popDisposition {
-    if (willHandlePopInternally) {
-      return RoutePopDisposition.pop;
-    }
-    return super.popDisposition;
-  }
-
-  @override
-  Widget buildPage(BuildContext context, Animation<double> animation,
-      Animation<double> secondaryAnimation) {
-    final Widget child = buildContent(context);
-    final Widget result = Semantics(
-      scopesRoute: true,
-      explicitChildNodes: true,
-      child: child,
-    );
-
-    return result;
-  }
-
-  // Called by _CupertinoBackGestureDetector when a pop ("back") drag start
-  // gesture is detected. The returned controller handles all of the subsequent
-  // drag events.
-  static _CupertinoBackGestureController<T> _startPopGesture<T>(
-      PageRoute<T> route) {
-    assert(_isPopGestureEnabled(route));
-
-    return _CupertinoBackGestureController<T>(
-      navigator: route.navigator!,
-      controller: route.controller!, // protected access
-    );
-  }
-
-  /// Returns a [CupertinoFullscreenDialogTransition] if [route] is a full
-  /// screen dialog, otherwise a [CupertinoPageTransition] is returned.
-  ///
-  /// Used by [CupertinoPageRoute.buildTransitions].
-  ///
-  /// This method can be applied to any [PageRoute], not just
-  /// [CupertinoPageRoute]. It's typically used to provide a Cupertino style
-  /// horizontal transition for material widgets when the target platform
-  /// is [TargetPlatform.iOS].
-  ///
-  /// See also:
-  ///
-  ///  * [NoShadowCupertinoPageTransitionsBuilder], which uses this method to define a
-  ///    [PageTransitionsBuilder] for the [PageTransitionsTheme].
-  static Widget buildPageTransitions<T>(
-    PageRoute<T> route,
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-    Widget child,
-  ) {
-    // Check if the route has an animation that's currently participating
-    // in a back swipe gesture.
-    //
-    // In the middle of a back gesture drag, let the transition be linear to
-    // match finger motions.
-    final bool linearTransition = isPopGestureInProgress(route);
-    if (route.fullscreenDialog) {
-      return CupertinoFullscreenDialogTransition(
-        primaryRouteAnimation: animation,
-        secondaryRouteAnimation: secondaryAnimation,
-        linearTransition: linearTransition,
-        child: child,
-      );
-    } else {
-      return CupertinoPageTransition(
-        primaryRouteAnimation: animation,
-        secondaryRouteAnimation: secondaryAnimation,
-        linearTransition: linearTransition,
-        child: _CupertinoBackGestureDetector<T>(
-          enabledCallback: () => _isPopGestureEnabled<T>(route),
-          onStartPopGesture: () => _startPopGesture<T>(route),
-          child: child,
-        ),
-      );
-    }
-  }
-
-  @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation,
-      Animation<double> secondaryAnimation, Widget child) {
-    return buildPageTransitions<T>(
-        this, context, animation, secondaryAnimation, child);
-  }
-}
-
 /// A modal route that replaces the entire screen with an iOS transition.
 ///
 /// {@macro flutter.cupertino.cupertinoRouteTransitionMixin}
@@ -307,7 +75,9 @@ mixin CustomCupertinoRouteTransitionMixin<T> on PageRoute<T> {
 ///    bottom with multiple pages.
 ///  * [CupertinoPage], for a [Page] version of this class.
 class CupertinoPageRoute<T> extends PageRoute<T>
-    with CustomCupertinoRouteTransitionMixin<T> {
+    with
+        CupertinoRouteTransitionMixin<T>,
+        CupertinoRouteTransitionOverrideMixin<T> {
   /// Creates a page route for use in an iOS designed app.
   ///
   /// The [builder], [maintainState], and [fullscreenDialog] arguments must not
@@ -336,6 +106,24 @@ class CupertinoPageRoute<T> extends PageRoute<T>
 
   @override
   String get debugLabel => '${super.debugLabel}(${settings.name})';
+}
+
+/// A mixin that implements methods and/or parameters of a [PageRoute].
+///
+/// Meant to be used as an override of methods/parameters implemented in
+/// [CupertinoRouteTransitionMixin].
+mixin CupertinoRouteTransitionOverrideMixin<T> on PageRoute<T> {
+  // fixes https://github.com/flutter/flutter/issues/105738
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  RoutePopDisposition get popDisposition {
+    if (willHandlePopInternally) {
+      return RoutePopDisposition.pop;
+    }
+    return super.popDisposition;
+  }
 }
 
 /// Provides an iOS-style page transition animation.
@@ -895,8 +683,17 @@ class _CupertinoEdgeShadowPainter extends BoxPainter {
 /// A custom cupertino transition builder to fix unwanted shadows in nested navigator
 ///
 /// This fixes the issue referenced here
-// https://stackoverflow.com/questions/53457772/why-there-is-a-shadow-between-nested-navigator
-// https://stackoverflow.com/questions/68986632/rid-of-elevation-of-nested-flutter-navigator-2-0
+/// https://stackoverflow.com/questions/53457772/why-there-is-a-shadow-between-nested-navigator
+/// https://stackoverflow.com/questions/68986632/rid-of-elevation-of-nested-flutter-navigator-2-0
+@Deprecated(
+  'The issue, this builder fixes, was already fixed in the freamework in v3.0.0'
+  '(https://github.com/flutter/flutter/pull/95537, '
+  'https://docs.flutter.dev/release/release-notes/release-notes-3.0.0) '
+  'so there is no more reason to use this builder. '
+  'Will be deleted in the next major release. '
+  'If you still need this builder for other reasons, '
+  'use CupertinoPageTransitionsBuilder instead. as it is completely identic',
+)
 class NoShadowCupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
   /// Constructs a page transition animation that matches the iOS transition.
   const NoShadowCupertinoPageTransitionsBuilder();
@@ -909,7 +706,7 @@ class NoShadowCupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    return CustomCupertinoRouteTransitionMixin.buildPageTransitions<T>(
+    return CupertinoRouteTransitionMixin.buildPageTransitions<T>(
         route, context, animation, secondaryAnimation, child);
   }
 }


### PR DESCRIPTION
**Issue**: `CupertinoNavigationBar` and `CupertinoSliverNavigationBar` can not get current route title and previous route title.

**Сonsequences**: 
- In case of title: if a title was not provided to `CupertinoNavigationBar`/`CupertinoSliverNavigationBar` then [an `AssertionError` will be thrown: "largeTitle was not provided and there was no title from the route." in debug mode. In release - throws a runtime error](https://github.com/flutter/flutter/blob/defa2b7443651446e7724ab1903d15518d707877/packages/flutter/lib/src/cupertino/nav_bar.dart#L1372C5-L1380C7).
- in case of previous screen title: the back label of `CupertinoNavigationBarBackButton` will be empty(if a string was not passed explicitly to `previousPageTitle`)

<details>
<summary>Code to reproduce:</summary>


```dart
import 'package:auto_route/auto_route.dart';
import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';

part 'auto_router.gr.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  MyApp({super.key});

  final _appRouter = MainRouter();

  @override
  Widget build(BuildContext context) {
    return MaterialApp.router(
      title: 'Material App',
      theme: ThemeData.light(),
      routerConfig: _appRouter.config(),
    );
  }
}

class BasePage extends StatelessWidget {
  const BasePage({
    super.key,
    required this.color,
    required this.availableNavigations,
  });

  @protected
  final Color color;

  @protected
  final List<PageRouteInfo<dynamic>> availableNavigations;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: CustomScrollView(
        slivers: [
          const CupertinoSliverNavigationBar(),
          SliverFillRemaining(
            hasScrollBody: false,
            child: ColoredBox(
              color: color,
              child: Column(
                children: [
                  const Spacer(),
                  for (final navigation in availableNavigations)
                    ElevatedButton(
                      onPressed: () {
                        context.router.push(navigation);
                      },
                      child: Text(navigation.routeName),
                    ),
                  const Spacer(),
                ],
              ),
            ),
          ),
        ],
      ),
    );
  }
}

@RoutePage()
class FirstPage extends BasePage {
  const FirstPage({
    super.key,
  }) : super(
          color: Colors.greenAccent,
          availableNavigations: const [SecondRoute()],
        );
}

@RoutePage()
class SecondPage extends BasePage {
  const SecondPage({
    super.key,
  }) : super(
          color: Colors.amberAccent,
          availableNavigations: const [FirstRoute()],
        );
}

@AutoRouterConfig()
class MainRouter extends _$MainRouter {
  @override
  RouteType get defaultRouteType => const RouteType.adaptive();

  @override
  List<AutoRoute> get routes => [
        AutoRoute(
          path: '/',
          page: FirstRoute.page,
          title: (context, data) => 'First Page',
        ),
        AutoRoute(
          path: '/second',
          page: SecondRoute.page,
          title: (context, data) => 'Second Page',
        ),
      ];
}

```
</details>

<details>
<summary>Expected behaviour:</summary>

https://github.com/Milad-Akarie/auto_route_library/assets/52368972/a956acbf-70fa-479f-b7e8-8eb008a5c59a
</details>

</details>

<details>
<summary>Current behaviour:</summary>

[an `AssertionError` will be thrown: "largeTitle was not provided and there was no title from the route." in debug mode. In release - throws a runtime error](https://github.com/flutter/flutter/blob/defa2b7443651446e7724ab1903d15518d707877/packages/flutter/lib/src/cupertino/nav_bar.dart#L1372C5-L1380C7)
</details>

So this PR fixes this issue, and implements the expected behaviour, namely, because `CupertinoNavigationBar`, `CupertinoSliverNavigationBar` and `CupertinoNavigationBarBackButton` are expecting to see a route mixed with `CupertinoRouteTransitionMixin`[(#1](https://github.com/flutter/flutter/blob/defa2b7443651446e7724ab1903d15518d707877/packages/flutter/lib/src/cupertino/nav_bar.dart#L1578C25-L1578C54) and [#2](https://github.com/flutter/flutter/blob/defa2b7443651446e7724ab1903d15518d707877/packages/flutter/lib/src/cupertino/nav_bar.dart#L1193)) in this PR `CustomCupertinoRouteTransitionMixin` is removed and replaced with `CupertinoRouteTransitionMixin`, so that now the type check will return `true`, and current route title and previous route title will be obtained correctly.

_Note: there are issues with the previous route title(previous screen title right next to back chevron) when using nested routes. I will try to fix it in another PR_