### PR TITLE
fix: minimum flutter version constraint

### DIFF
--- a/auto_route/pubspec.yaml
+++ b/auto_route/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/Milad-Akarie/auto_route_library
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.13.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
The latest release of `auto_route` includes the `PopScope` widget, which was introduced in  Fluter version `3.14.0-7.0.pre`, and in stable `3.16.0`. I just updated the minimum Flutter SDK constraint to indicate that.

The latest release of auto_route (`7.8.5`) will fail to install for users who are not on the latest stable version. You may want to consider [retracting](https://dart.dev/tools/pub/publishing#retract) that release and publishing a new version with an updated SDK constraint.