### PR TITLE
Dispose ticker

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -648,6 +648,12 @@ class _AutoTabsRouterTabBarState extends AutoTabsRouterState<_AutoTabsRouterTabB
     });
   }
 
+  @override
+  void dispose(){
+    _tabController.dispose();
+    super.dispose();
+  }
+
   void _updateTabController() {
     _tabController = TabController(
       animationDuration: widget.duration,


### PR DESCRIPTION
The ticker was not disposed because the TabController was not disposed this leads to errors, which we encountered in one of our integration tests.