### PR TITLE
Migrate to package:web

### DIFF
--- a/auto_route/lib/src/router/controller/navigation_history/navigation_history_base.dart
+++ b/auto_route/lib/src/router/controller/navigation_history/navigation_history_base.dart
@@ -4,7 +4,7 @@ import 'package:flutter/widgets.dart';
 
 import 'navigation_history.dart'
     if (dart.library.io) 'native_navigation_history.dart'
-    if (dart.library.html) 'web_navigation_history.dart';
+    if (dart.library.js_interop) 'web_navigation_history.dart';
 
 /// An abstraction on a navigation history tracker
 /// that utilises browser history on web and mimics it on native

--- a/auto_route/lib/src/router/controller/navigation_history/web_navigation_history.dart
+++ b/auto_route/lib/src/router/controller/navigation_history/web_navigation_history.dart
@@ -1,7 +1,7 @@
-import 'package:auto_route/auto_route.dart';
+import 'dart:js_interop';
 
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
+import 'package:auto_route/auto_route.dart';
+import 'package:web/web.dart';
 
 import 'navigation_history_base.dart';
 
@@ -14,7 +14,7 @@ class NavigationHistoryImpl extends NavigationHistory {
   @override
   final StackRouter router;
 
-  final _history = html.window.history;
+  final _history = window.history;
 
   @override
   void back() {
@@ -22,7 +22,7 @@ class NavigationHistoryImpl extends NavigationHistory {
   }
 
   int get _currentIndex {
-    final state = _history.state;
+    final state = _history.state.dartify();
     if (state is Map) {
       return state['serialCount'] ?? 0;
     }

--- a/auto_route/pubspec.yaml
+++ b/auto_route/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   path: ^1.9.0
   collection: ^1.17.0
   meta: ^1.11.0
+  web: ^0.5.1
 
 
 


### PR DESCRIPTION
Migrate from dart:html to package:web to support wasm

[Migrate to package:web](https://dart.dev/interop/js-interop/package-web#conditional-imports)
