### PR TITLE
Fix NavigationResolver redirect

### DIFF
--- a/auto_route/lib/src/router/controller/auto_route_guard.dart
+++ b/auto_route/lib/src/router/controller/auto_route_guard.dart
@@ -23,7 +23,7 @@ abstract class AutoRouteGuard {
   }
 }
    */
-  void onNavigation(
+  FutureOr<void> onNavigation(
     NavigationResolver resolver,
     StackRouter router,
   );
@@ -195,16 +195,27 @@ class NavigationResolver {
     OnNavigationFailure? onFailure,
     bool replace = false,
   }) async {
-    return _router._redirect(
-      route,
-      onFailure: onFailure,
-      replace: replace,
-      onMatch: (scope, match) async {
-        await _completer.future;
-        scope.markUrlStateForReplace();
-        scope._removeRoute(match);
-      },
-    );
+    T? result;
+    try {
+      result = await _router._redirect<T?>(
+        route,
+        onFailure: onFailure,
+        replace: replace,
+        onMatch: (scope, match) {
+          scope.markUrlStateForReplace();
+          scope._removeRoute(match);
+        },
+      );
+    } finally {
+      _completer.complete(
+        const ResolverResult(
+          continueNavigation: false,
+          reevaluateNext: false,
+        ),
+      );
+    }
+
+    return result;
   }
 
   /// Helpful for when you want to revert to the previous

--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -1599,16 +1599,21 @@ abstract class StackRouter extends RoutingController {
     for (var guard in guards) {
       final completer = Completer<ResolverResult>();
       activeGuardObserver.add(guard);
-      guard.onNavigation(
-        NavigationResolver(
+      try {
+        await guard.onNavigation(
+          NavigationResolver(
+            this,
+            completer,
+            route,
+            pendingRoutes: pendingRoutes,
+            isReevaluating: isReevaluating,
+          ),
           this,
-          completer,
-          route,
-          pendingRoutes: pendingRoutes,
-          isReevaluating: isReevaluating,
-        ),
-        this,
-      );
+        );
+      } catch (_) {
+        activeGuardObserver.remove(guard);
+        rethrow;
+      }
       final result = await completer.future;
       breakOnReevaluate |= result.reevaluateNext;
       if (!result.continueNavigation) {

--- a/auto_route/test/route_guard/guard.dart
+++ b/auto_route/test/route_guard/guard.dart
@@ -1,0 +1,20 @@
+import 'package:auto_route/auto_route.dart';
+
+class RedirectOrNextGuard extends AutoRouteGuard {
+  RedirectOrNextGuard();
+
+  PageRouteInfo? redirectTo;
+
+  void setRedirect(PageRouteInfo? it) {
+    redirectTo = it;
+  }
+
+  @override
+  Future<void> onNavigation(NavigationResolver resolver, StackRouter router) async {
+    if (redirectTo != null) {
+      resolver.redirect(redirectTo!);
+    } else {
+      resolver.next();
+    }
+  }
+}

--- a/auto_route/test/route_guard/guard_test.dart
+++ b/auto_route/test/route_guard/guard_test.dart
@@ -1,0 +1,62 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../main_router.dart';
+import '../simple_router/router_test.dart';
+import 'guard.dart';
+import 'router.dart';
+
+void main() {
+  late GuardTestRouter router;
+  late RedirectOrNextGuard firstRouteGuard;
+  late RedirectOrNextGuard secondRouteGuard;
+  setUp(() {
+    firstRouteGuard = RedirectOrNextGuard();
+    secondRouteGuard = RedirectOrNextGuard();
+    router = GuardTestRouter(
+      firstRouteGuard: firstRouteGuard,
+      secondRouteGuard: secondRouteGuard,
+    )..ignorePopCompleters = true;
+  });
+
+  test(
+      'Pushing first route should not redirect to second route if no redirect is set',
+      () async {
+    final listener = MockListener();
+    router.navigationHistory.addListener(listener.call);
+
+    expect(router.currentHierarchy(), []);
+
+    await router.push(const FirstRoute());
+
+    expect(
+      router.currentHierarchy(),
+      [const HierarchySegment(FirstRoute.name)],
+    );
+
+    verify(listener()).called(1);
+    verifyNoMoreInteractions(listener);
+  });
+
+  test(
+      'Pushing first route after setting redirect in guard should redirect to second route',
+      () async {
+    final listener = MockListener();
+    router.navigationHistory.addListener(listener.call);
+
+    expect(router.currentHierarchy(), []);
+
+    firstRouteGuard.setRedirect(const SecondRoute());
+
+    await router.push(const FirstRoute()).timeout(const Duration(seconds: 1));
+
+    expect(
+      router.currentHierarchy(),
+      [const HierarchySegment(SecondRoute.name)],
+    );
+
+    verify(listener()).called(1);
+    verifyNoMoreInteractions(listener);
+  });
+}

--- a/auto_route/test/route_guard/guard_widget_test.dart
+++ b/auto_route/test/route_guard/guard_widget_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../main_router.dart';
+import '../router_test_utils.dart';
+import 'guard.dart';
+import 'router.dart';
+
+void main() {
+  late GuardTestRouter router;
+  late RedirectOrNextGuard firstRouteGuard;
+  late RedirectOrNextGuard secondRouteGuard;
+  late _Listenable reevaluate;
+
+  setUp(() {
+    firstRouteGuard = RedirectOrNextGuard();
+    secondRouteGuard = RedirectOrNextGuard();
+    reevaluate = _Listenable();
+    router = GuardTestRouter(
+      firstRouteGuard: firstRouteGuard,
+      secondRouteGuard: secondRouteGuard,
+    )..ignorePopCompleters = true;
+  });
+
+  tearDown(() {
+    reevaluate.dispose();
+  });
+
+  testWidgets(
+      'Router should redirect to second route after setting redirect in guard',
+      (WidgetTester tester) async {
+    firstRouteGuard.setRedirect(const SecondRoute());
+    await pumpRouterApp(tester, router, reevaluateListenable: reevaluate);
+    await tester.pumpAndSettle();
+    expect(find.text(SecondRoute.name), findsOneWidget);
+    expect(router.urlState.url, '/second-route');
+  });
+
+  testWidgets(
+      'Router should redirect to second route after setting redirect target in guard '
+      'and telling router to reevaluate', (WidgetTester tester) async {
+    await pumpRouterApp(tester, router, reevaluateListenable: reevaluate);
+
+    firstRouteGuard.setRedirect(const SecondRoute());
+    reevaluate.notify();
+
+    await tester.pumpAndSettle();
+    expect(find.text(SecondRoute.name), findsOneWidget);
+    expect(router.urlState.url, '/second-route');
+  });
+
+  testWidgets(
+      'Router should redirect to first route after redirecting to second route from first route and '
+      'updating redirect target in guard and telling router to reevaluate',
+      (WidgetTester tester) async {
+    await pumpRouterApp(tester, router, reevaluateListenable: reevaluate);
+
+    firstRouteGuard.setRedirect(const SecondRoute());
+    reevaluate.notify();
+
+    await tester.pumpAndSettle();
+    expect(find.text(SecondRoute.name), findsOneWidget);
+    expect(router.urlState.url, '/second-route');
+
+    secondRouteGuard.setRedirect(const FirstRoute());
+    firstRouteGuard.setRedirect(null);
+    reevaluate.notify();
+
+    await tester.pumpAndSettle();
+    expect(find.text(FirstRoute.name), findsOneWidget);
+    expect(router.urlState.url, '/');
+  });
+}
+
+class _Listenable extends ChangeNotifier {
+  void notify() {
+    notifyListeners();
+  }
+}

--- a/auto_route/test/route_guard/router.dart
+++ b/auto_route/test/route_guard/router.dart
@@ -1,0 +1,27 @@
+import 'package:auto_route/auto_route.dart';
+
+import '../main_router.dart';
+
+class GuardTestRouter extends MainRouter {
+  GuardTestRouter({
+    required this.firstRouteGuard,
+    required this.secondRouteGuard,
+  });
+
+  @override
+  List<AutoRoute> get routes => [
+        AutoRoute(
+          page: FirstRoute.page,
+          path: '/',
+          guards: [firstRouteGuard],
+        ),
+        AutoRoute(
+          page: SecondRoute.page,
+          guards: [secondRouteGuard],
+        ),
+      ];
+
+  final AutoRouteGuard firstRouteGuard;
+
+  final AutoRouteGuard secondRouteGuard;
+}

--- a/auto_route/test/router_test_utils.dart
+++ b/auto_route/test/router_test_utils.dart
@@ -6,6 +6,7 @@ Future<void> pumpRouterApp(
   WidgetTester tester,
   RootStackRouter router, {
   String? initialLink,
+  Listenable? reevaluateListenable,
   NavigatorObserversBuilder observers =
       AutoRouterDelegate.defaultNavigatorObserversBuilder,
 }) {
@@ -14,6 +15,7 @@ Future<void> pumpRouterApp(
         MaterialApp.router(
           routeInformationParser: router.defaultRouteParser(),
           routerDelegate: router.delegate(
+            reevaluateListenable: reevaluateListenable,
             deepLinkBuilder: (link) =>
                 initialLink == null ? link : DeepLink.path(initialLink),
             navigatorObservers: observers,


### PR DESCRIPTION
The current implementation of `NavigationResolver`, which is used in guards, does not complete after a redirect (it does not complete the internal `_completer`). 
This leads to incorrect behavior following a second redirect from the guard.

For example:
1. Add `AuthGuard` with a redirect to the login page if the user is unauthorized.
2. Set `reevaluateListenable`.
3. On `AuthService.logout`, the following sequence occurs:
    - `AuthService.isAuthorized` is set to `false`.
    - `reevaluateListenable` is notified.
    - `reevaluateGuards` is triggered by `reevaluateListenable`.
    - `_pushAllGuarded` is called by `reevaluateGuards`.
    - `AuthGuard.onNavigation` is invoked from `_pushAllGuarded`.
    -  A redirect to `SignInRoute` is initiated.
4. At this point, everything functions as expected.
5. The user logs in again.
6. On logout, the following sequence occurs:
    - `AuthService.isAuthorized` is set to `false` again.
    - `reevaluateListenable` is notified.
    - `reevaluateGuards` is triggered.
    - The process gets stuck on `activeGuardObserver.guardInProgress`.
7. No further action takes place.

The problem is in the `NavigationResolver.redirect` method. 
`NavigationResolver` contains a `Completer` which is used in `StackRouter._canNavigate`.
However, the `redirect` method in `NavigationResolver` never completes this `Completer`.
As a result, the current guard is never removed from `activeGuardObserver`.

https://github.com/Milad-Akarie/auto_route_library/blob/66a9faa678458157fc73501f8ba14ac6dd3c9ee5/auto_route/lib/src/router/controller/auto_route_guard.dart#L193-L208

https://github.com/Milad-Akarie/auto_route_library/blob/66a9faa678458157fc73501f8ba14ac6dd3c9ee5/auto_route/lib/src/router/controller/routing_controller.dart#L1600-L1624

So I've fixed this issue and also added tests (but I'm not very experienced with testing in Flutter :D).

This PR also likely addresses issue #1953 (I've encountered a similar problem during testing). 
I've changed the return type of `onNavigation` to `FutureOr<void>` and added an `await` in `_canNavigate` to ensure it waits until the redirect is complete.

Additionally, I'm not entirely clear on the purpose of calling `scope.markUrlStateForReplace(); scope._removeRoute(match);` in `NavigationResolver.redirect`. The only place where `StackRouter._redirect` is used is in this context, and `StackRouter._redirect` calls `scope.markUrlStateForReplace();` if the redirect flag is set. 
I got a bit lost at this point :D. So, I decided not to modify this part.

@Milad-Akarie, could you please review the changes in this PR when you have a moment?