### PR TITLE
Parameters getList support defaultValue

### DIFF
--- a/auto_route/lib/src/common/parameters.dart
+++ b/auto_route/lib/src/common/parameters.dart
@@ -161,8 +161,8 @@ class Parameters {
   }
 
   /// returns the value corresponding with [key] as nullable [List<String>]
-  List<String> getList(String key) {
-    var val = _params[key];
+  List<String> getList(String key, [List<String>? defaultValue]) {
+    var val = _params[key] ?? defaultValue;
     if (val == null) {
       throw MissingRequiredParameterError(
           'Failed to parse [List<String>] $key value from ${_params[key]}');


### PR DESCRIPTION

generator will  generate 
```
queryParams.getList(
                'relationships',
                const [],
              )
```

but getList dosent support default value.



full code:
```dart
@RoutePage()
class AddPalSlipRelationshipPage extends LinjiePage {
  final List<String> relationships;

  const AddPalSlipRelationshipPage(
      {super.key, @QueryParam("relationships") this.relationships = const [],});

  @override
  ConsumerState<ConsumerStatefulWidget> createState() {
    return _SelectRelationshipPage();
  }
}


```

```dart
  static PageInfo page = PageInfo(
    name,
    builder: (data) {
      final queryParams = data.queryParams;
      final args = data.argsAs<AddPalSlipRelationshipRouteArgs>(
          orElse: () => AddPalSlipRelationshipRouteArgs(
                  relationships: queryParams.getList(
                'relationships',
                const [],
              )));
      return AddPalSlipRelationshipPage(
        key: args.key,
        relationships: args.relationships,
      );
    },
  );
```