### PR TITLE
Give RedirectRoutes a unique name to allow multiple in a collection

### DIFF
--- a/auto_route/lib/src/route/auto_route_config.dart
+++ b/auto_route/lib/src/route/auto_route_config.dart
@@ -296,6 +296,9 @@ class RedirectRoute extends AutoRoute {
           page: PageInfo.redirect,
           fullMatch: true,
         );
+
+  @override
+  String get name => "${page.name}-$path-$redirectTo";
 }
 
 /// Builds an [AutoRoute] instance with [RouteType.material] type


### PR DESCRIPTION
Resolves issue #2035  where only the last redirect in a collection is persisted. I overrode `RedirectRoute`'s `name` property appended the `path` and `redirectTo` to the `page.name` to make redirect routes unique from one another. I also added a handful of unit tests verifying the fix, and verified that the rest of the test suite passes. Please let me know if there is an alternative fix you would prefer to this issue. Thank you again.