### PR TITLE
Correct AutoTabsRouterPageViewState logic determining when navigation observers should be notified

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -515,13 +515,7 @@ class _AutoTabsRouterPageViewState
     _updatePageController();
     _didInitTabRoute(_controller!.activeIndex);
     _controller!.addListener(() {
-      var controllerPage = 0;
-      try {
-        controllerPage = _pageController.page!.toInt();
-      } catch (e) {
-        controllerPage = 0;
-      }
-      if (_controller!.activeIndex != controllerPage) {
+      if (_controller!.activeIndex != (_controller?.previousIndex ?? 0)) {
         _didChangeTabRoute(
             _controller!.activeIndex, _controller!.previousIndex!);
       }


### PR DESCRIPTION
The truncation of the `_pageController.page` variable would return the 'new' tab index when swiping-right (decrementing the tab index). 
This means the comparison `if (_controller!.activeIndex != controllerPage)` would eval to false - skipping notification.
Seems like we can just use the controllers `previousIndex` for this.
Fixes #2044 