### PR TITLE
Fix popping when there is no entries in nested router

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -1146,8 +1146,7 @@ abstract class StackRouter extends RoutingController {
   @optionalTypeArgs
   Future<bool> maybePop<T extends Object?>([T? result]) async {
     final NavigatorState? navigator = _navigatorKey.currentState;
-    if (navigator == null) return SynchronousFuture<bool>(false);
-    if (await navigator.maybePop<T>(result)) {
+    if (await navigator?.maybePop<T>(result) ?? false) {
       return true;
     } else if (_parent != null) {
       return _parent!.maybePop<T>(result);


### PR DESCRIPTION
App closes when nested router has no entries, according to code and logic it should pop in parent router but it doesn't. I fixed that behavior.