### PR TITLE
refactor(custom_route): update route duration type from int to Duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1402,7 +1402,7 @@ CustomRoute(
   page: LoginRoute.page,
   // TransitionsBuilders class contains a preset of common transitions builders.
   transitionsBuilder: TransitionsBuilders.slideBottom,
-  durationInMilliseconds: 400,
+  duration: Duration(milliseconds: 400),
 )
 ```
 

--- a/auto_route/lib/src/route/auto_route_config.dart
+++ b/auto_route/lib/src/route/auto_route_config.dart
@@ -409,8 +409,12 @@ class CustomRoute<R> extends AutoRoute {
     super.allowSnapshotting = true,
     RouteTransitionsBuilder? transitionsBuilder,
     CustomRouteBuilder? customRouteBuilder,
+    @Deprecated('Use duration instead')
     int? durationInMilliseconds,
+    @Deprecated('Use reverseDuration instead')
     int? reverseDurationInMilliseconds,
+    Duration? duration,
+    Duration? reverseDuration,
     bool opaque = true,
     bool barrierDismissible = true,
     String? barrierLabel,
@@ -422,8 +426,14 @@ class CustomRoute<R> extends AutoRoute {
           type: RouteType.custom(
             transitionsBuilder: transitionsBuilder,
             customRouteBuilder: customRouteBuilder,
-            durationInMilliseconds: durationInMilliseconds,
-            reverseDurationInMilliseconds: reverseDurationInMilliseconds,
+            duration: duration ??
+                (durationInMilliseconds != null
+                    ? Duration(milliseconds: durationInMilliseconds)
+                    : null),
+            reverseDuration: reverseDuration ??
+                (reverseDurationInMilliseconds != null
+                    ? Duration(milliseconds: reverseDurationInMilliseconds)
+                    : null),
             opaque: opaque,
             barrierDismissible: barrierDismissible,
             barrierLabel: barrierLabel,

--- a/auto_route/lib/src/route/route_type.dart
+++ b/auto_route/lib/src/route/route_type.dart
@@ -45,11 +45,15 @@ abstract class RouteType {
   }) = AdaptiveRouteType;
 
   /// Builds a [CustomRouteType] route type
-  const factory RouteType.custom({
+  factory RouteType.custom({
     RouteTransitionsBuilder? transitionsBuilder,
     CustomRouteBuilder? customRouteBuilder,
+    @Deprecated('Use duration instead')
     int? durationInMilliseconds,
+    @Deprecated('Use reverseDuration instead')
     int? reverseDurationInMilliseconds,
+    Duration? duration,
+    Duration? reverseDuration,
     bool opaque,
     bool barrierDismissible,
     String? barrierLabel,
@@ -138,15 +142,15 @@ class CustomRouteType extends RouteType with PredictiveBackGestureMixin {
   ///  },
   final CustomRouteBuilder? customRouteBuilder;
 
-  /// route transition duration in milliseconds
+  /// route transition duration
   /// is passed to [PageRouteBuilder]
   /// this property is ignored unless a [transitionBuilder] is provided
-  final int? durationInMilliseconds;
+  final Duration? duration;
 
-  /// route reverse transition duration in milliseconds
+  /// route reverse transition duration
   /// is passed to [PageRouteBuilder]
   /// this property is ignored unless a [transitionBuilder] is provided
-  final int? reverseDurationInMilliseconds;
+  final Duration? reverseDuration;
 
   /// passed to the barrierDismissible property in [PageRouteBuilder]
   ///
@@ -170,18 +174,30 @@ class CustomRouteType extends RouteType with PredictiveBackGestureMixin {
   final RouteTransitionsBuilder? predictiveBackPageTransitionsBuilder;
 
   /// Default constructor
-  const CustomRouteType({
+  CustomRouteType({
     this.customRouteBuilder,
     this.barrierLabel,
     this.barrierColor,
     this.transitionsBuilder,
-    this.durationInMilliseconds,
-    this.reverseDurationInMilliseconds,
     super.opaque,
     this.barrierDismissible = false,
     this.enablePredictiveBackGesture = false,
     this.predictiveBackPageTransitionsBuilder,
-  }) : super._();
+    @Deprecated('Use duration instead')
+    int? durationInMilliseconds,
+    @Deprecated('Use reverseDuration instead')
+    int? reverseDurationInMilliseconds,
+    Duration? duration,
+    Duration? reverseDuration,
+  })  : duration = duration ??
+            (durationInMilliseconds != null
+                ? Duration(milliseconds: durationInMilliseconds)
+                : null),
+        reverseDuration = reverseDuration ??
+            (reverseDurationInMilliseconds != null
+                ? Duration(milliseconds: reverseDurationInMilliseconds)
+                : null),
+        super._();
 
   @override
   bool operator ==(Object other) =>
@@ -191,9 +207,8 @@ class CustomRouteType extends RouteType with PredictiveBackGestureMixin {
           runtimeType == other.runtimeType &&
           transitionsBuilder == other.transitionsBuilder &&
           customRouteBuilder == other.customRouteBuilder &&
-          durationInMilliseconds == other.durationInMilliseconds &&
-          reverseDurationInMilliseconds ==
-              other.reverseDurationInMilliseconds &&
+          duration == other.duration &&
+          reverseDuration == other.reverseDuration &&
           barrierDismissible == other.barrierDismissible &&
           barrierLabel == other.barrierLabel &&
           barrierColor == other.barrierColor;
@@ -203,8 +218,8 @@ class CustomRouteType extends RouteType with PredictiveBackGestureMixin {
       super.hashCode ^
       transitionsBuilder.hashCode ^
       customRouteBuilder.hashCode ^
-      durationInMilliseconds.hashCode ^
-      reverseDurationInMilliseconds.hashCode ^
+      duration.hashCode ^
+      reverseDuration.hashCode ^
       barrierDismissible.hashCode ^
       barrierLabel.hashCode ^
       barrierColor.hashCode;

--- a/auto_route/lib/src/router/auto_route_page.dart
+++ b/auto_route/lib/src/router/auto_route_page.dart
@@ -311,14 +311,12 @@ mixin _CustomPageRouteTransitionMixin<T> on PageRoute<T> {
   Widget buildContent(BuildContext context);
 
   @override
-  Duration get transitionDuration => Duration(
-        milliseconds: routeType.durationInMilliseconds ?? 300,
-      );
+  Duration get transitionDuration =>
+      routeType.duration ?? const Duration(milliseconds: 300);
 
   @override
-  Duration get reverseTransitionDuration => Duration(
-        milliseconds: routeType.reverseDurationInMilliseconds ?? 300,
-      );
+  Duration get reverseTransitionDuration =>
+      routeType.reverseDuration ?? const Duration(milliseconds: 300);
 
   @override
   bool get barrierDismissible => routeType.barrierDismissible;


### PR DESCRIPTION
## Description

Update the `durationInMilliseconds` and `reverseDurationInMilliseconds` parameters in the CustomRoute to use the native [Duration](https://api.dart.dev/dart-core/Duration-class.html) type.

The Duration type is the standard type for representing durations in Dart, so there is no need to use an Int type to represent route durations.