### PR TITLE
Add required keyword to named required parameters in function parameters' arguments

### DIFF
--- a/auto_route_generator/lib/src/models/route_parameter_config.dart
+++ b/auto_route_generator/lib/src/models/route_parameter_config.dart
@@ -246,20 +246,31 @@ class FunctionParamConfig extends ParamConfig {
       params.where((p) => p.isPositional && p.isOptional).toList();
 
   /// Returns the list of named parameters
-  List<ParamConfig> get namedParams =>
-      params.where((p) => p.isNamed).toList(growable: false);
+  List<ParamConfig> get namedOptionalParams =>
+      params.where((p) => p.isNamed && p.isOptional).toList(growable: false);
+
+  /// Returns the list of named required parameters
+  List<ParamConfig> get namedRequiredParams =>
+      params.where((p) => p.isNamed && !p.isOptional).toList(growable: false);
 
   /// Returns A function reference of the function type
-  _code.FunctionType get funRefer => _code.FunctionType((b) => b
-    ..returnType = returnType.refer
-    ..requiredParameters.addAll(requiredParams.map((e) => e.type.refer))
-    ..optionalParameters.addAll(optionalParams.map((e) => e.type.refer))
-    ..isNullable = type.isNullable
-    ..namedParameters.addAll(
-      {}..addEntries(namedParams.map(
-          (e) => MapEntry(e.name, e.type.refer),
-        )),
-    ));
+  _code.FunctionType get funRefer => _code.FunctionType(
+        (b) => b
+          ..returnType = returnType.refer
+          ..requiredParameters.addAll(requiredParams.map((e) => e.type.refer))
+          ..optionalParameters.addAll(optionalParams.map((e) => e.type.refer))
+          ..isNullable = type.isNullable
+          ..namedParameters.addAll(
+            {}..addEntries(namedOptionalParams.map(
+                (e) => MapEntry(e.name, e.type.refer),
+              )),
+          )
+          ..namedRequiredParameters.addAll(
+            {}..addEntries(namedRequiredParams.map(
+                (e) => MapEntry(e.name, e.type.refer),
+              )),
+          ),
+      );
 }
 
 /// Holds information about a path parameter


### PR DESCRIPTION
This PR allows the generator add the `required` to named parameters in function parameters' arguments. 

In the example screen below, the `onPressed` parameter is a function and `name` is a required named parameter. 

```dart
@RoutePage()
class MainPage extends StatelessWidget {
  const MainPage({
    required this.onPressed,
  });

  final void Function({required String name}) onPressed;

  @override
  Widget build(BuildContext context) {
    return const Scaffold(
      body: Center(
        child: Text('Hello World!'),
      ),
    );
  }
}
```

In the current version of auto_route, the generated code omits the `required` keyword by outputting: 

```dart
required void Function({String name}) onPressed,
```

This PR fixes it by outputting: 

```dart
required void Function({required String name}) onPressed,
```

### Screenshot:

<img width="100%" alt="auto_route_fix_function_required_keyword" src="https://github.com/user-attachments/assets/e337fad1-bf2b-4337-85d8-9b29fc54a446" />


### Demo

See [auto_route_fix_demo](https://github.com/victoreronmosele/auto_route_fix_demo) for the [before](https://github.com/victoreronmosele/auto_route_fix_demo/blob/main/before_fix/lib/app_router.gr.dart) and [after](https://github.com/victoreronmosele/auto_route_fix_demo/blob/main/after_fix/lib/app_router.gr.dart). 

Closes #1867 and #2064

