### PR TITLE
fix: re-enable args equality by default

### DIFF
--- a/auto_route/CHANGELOG.md
+++ b/auto_route/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 10.0.2
+- **FIX**: enable args equality by default to avoid the need of migrating to `argsEquality: true`
+
 ## 10.0.1
- - **REFACTOR**(custom_route): update route duration type from int to Duration.
- - **FEAT**: add onGeneratePath callback to RootStackRouter to allow custom path generation.
+- **REFACTOR**(custom_route): update route duration type from int to Duration.
+- **FEAT**: add onGeneratePath callback to RootStackRouter to allow custom path generation.
+
 ## 10.0.0 [Minor Breaking Changes]
 - **BREAKING CHANGE**: DeepLink and DeepLink.path will now use 'navigate' instead of push unless specified
 - **BREAKING CHANGE**: ActiveGuardObserver.value will now return a GuardEntry instead of an AutoRouteGuard, use 'activeGuards' to get the list of active guards

--- a/auto_route/lib/src/common/auto_route_annotations.dart
+++ b/auto_route/lib/src/common/auto_route_annotations.dart
@@ -30,7 +30,9 @@ class AutoRouterConfig {
   /// defaults = const ['lib']
   final List<String> generateForDir;
 
-  /// Whether to generate equality operator and hashCode for route args
+  /// Whether to generate equality operator and hashCode for route args.
+  ///
+  /// Defaults to `true`.
   final bool argsEquality;
 
   /// default constructor
@@ -38,7 +40,7 @@ class AutoRouterConfig {
     this.replaceInRouteName = 'Page|Screen,Route',
     this.deferredLoading = false,
     this.generateForDir = const ['lib'],
-    this.argsEquality = false,
+    this.argsEquality = true,
   });
 }
 


### PR DESCRIPTION
After migrating to auto_route > 10, I noticed that some of our tests failed due to args equality being disabled. While this is somewhat mentioned in the `CHANGELOG`, it is not explicitly marked as a "_BREAKING CHANGE_", which it clearly is. Alternatively, providing a migration guide would clarify it, but ideally, args equality should be an opt-out feature rather than opt-in.