### PR TITLE
fix-focus-managment

### DIFF
--- a/auto_route/CHANGELOG.md
+++ b/auto_route/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 10.1.1
 - **FEAT**: expose routeTraversalEdgeBehavior property from the underlying Navigator to allow customization of navigation stack edge behavior.
+- **FIX**: improve focus and semantics handling in AutoTabsRouter IndexedStack to exclude inactive tabs from focus traversal and semantics tree while preserving widget state.
 ## 10.1.0
 - **FIX**: Fix tab routes observing issue where initiating tabs can be reported twice.
 - **FIX**: Generated code is not properly formatted #2174

--- a/auto_route/CHANGELOG.md
+++ b/auto_route/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 10.1.1
+- **FEAT**: expose routeTraversalEdgeBehavior property from the underlying Navigator to allow customization of navigation stack edge behavior.
 ## 10.1.0
 - **FIX**: Fix tab routes observing issue where initiating tabs can be reported twice.
 - **FIX**: Generated code is not properly formatted #2174
@@ -77,7 +79,6 @@ No changes, changelog fix only.
   inside the router. implementing AutoRouteGuard is no longer supported.
 - **BREAKING CHANGE**: `AutoRouterConfig.module` is removed as it's no longer
   needed. `PageRouteInfos` are now self-contained.
--
 
 For more info read the complete migration guide
 [Migrating to v9](https://github.com/Milad-Akarie/auto_route_library/blob/master/migrations/migrating_to_v9.md)

--- a/auto_route/lib/src/router/widgets/auto_route_navigator.dart
+++ b/auto_route/lib/src/router/widgets/auto_route_navigator.dart
@@ -38,6 +38,9 @@ class AutoRouteNavigator extends StatefulWidget {
   /// The clip behavior of the navigator
   final Clip clipBehavior;
 
+  /// The traversal edge behavior of the navigator
+  final TraversalEdgeBehavior? routeTraversalEdgeBehavior;
+
   /// Default constructor
   const AutoRouteNavigator({
     required this.router,
@@ -47,6 +50,7 @@ class AutoRouteNavigator extends StatefulWidget {
     this.declarativeRoutesBuilder,
     this.placeholder,
     this.clipBehavior = Clip.hardEdge,
+    this.routeTraversalEdgeBehavior,
     super.key,
   });
 
@@ -68,8 +72,7 @@ class AutoRouteNavigatorState extends State<AutoRouteNavigator> {
 
   void _updateDeclarativeRoutes() {
     final delegate = AutoRouterDelegate.of(context);
-    var newRoutes =
-        widget.declarativeRoutesBuilder!(widget.router.pendingRoutesHandler);
+    var newRoutes = widget.declarativeRoutesBuilder!(widget.router.pendingRoutesHandler);
     if (!const ListEquality().equals(newRoutes, _routesSnapshot)) {
       _routesSnapshot = newRoutes;
       widget.router.updateDeclarativeRoutes(newRoutes);
@@ -93,12 +96,9 @@ class AutoRouteNavigatorState extends State<AutoRouteNavigator> {
         ? Navigator(
             key: widget.router.navigatorKey,
             clipBehavior: widget.clipBehavior,
-            observers: [
-              widget.router.pagelessRoutesObserver,
-              ...widget.navigatorObservers
-            ],
-            restorationScopeId: widget.navRestorationScopeId ??
-                widget.router.routeData.restorationId,
+            routeTraversalEdgeBehavior: widget.routeTraversalEdgeBehavior ?? kDefaultRouteTraversalEdgeBehavior,
+            observers: [widget.router.pagelessRoutesObserver, ...widget.navigatorObservers],
+            restorationScopeId: widget.navRestorationScopeId ?? widget.router.routeData.restorationId,
             pages: widget.router.stack,
             onDidRemovePage: (page) {
               if (page is AutoRoutePage) {
@@ -117,17 +117,11 @@ class AutoRouteNavigatorState extends State<AutoRouteNavigator> {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<StackRouter>('router', widget.router));
-    properties.add(IterableProperty<NavigatorObserver>(
-        'navigatorObservers', widget.navigatorObservers));
-    properties.add(DiagnosticsProperty<RoutesBuilder>(
-        'declarativeRoutesBuilder', widget.declarativeRoutesBuilder));
-    properties.add(
-        DiagnosticsProperty<WidgetBuilder>('placeholder', widget.placeholder));
-    properties
-        .add(DiagnosticsProperty<Clip>('clipBehavior', widget.clipBehavior));
-    properties.add(DiagnosticsProperty<String?>(
-        'navRestorationScopeId', widget.navRestorationScopeId));
-    properties
-        .add(DiagnosticsProperty<RoutePopCallBack>('didPop', widget.didPop));
+    properties.add(IterableProperty<NavigatorObserver>('navigatorObservers', widget.navigatorObservers));
+    properties.add(DiagnosticsProperty<RoutesBuilder>('declarativeRoutesBuilder', widget.declarativeRoutesBuilder));
+    properties.add(DiagnosticsProperty<WidgetBuilder>('placeholder', widget.placeholder));
+    properties.add(DiagnosticsProperty<Clip>('clipBehavior', widget.clipBehavior));
+    properties.add(DiagnosticsProperty<String?>('navRestorationScopeId', widget.navRestorationScopeId));
+    properties.add(DiagnosticsProperty<RoutePopCallBack>('didPop', widget.didPop));
   }
 }

--- a/auto_route/lib/src/router/widgets/auto_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_router.dart
@@ -35,25 +35,27 @@ class AutoRouter extends StatefulWidget {
   /// The clip behavior of the navigator
   final Clip clipBehavior;
 
+  /// The traversal edge behavior of the navigator
+  final TraversalEdgeBehavior? traversalEdgeBehavior;
+
   /// Default constructor
   const AutoRouter({
     super.key,
-    this.navigatorObservers =
-        AutoRouterDelegate.defaultNavigatorObserversBuilder,
+    this.navigatorObservers = AutoRouterDelegate.defaultNavigatorObserversBuilder,
     this.builder,
     this.navRestorationScopeId,
     this.navigatorKey,
     this.inheritNavigatorObservers = true,
     this.placeholder,
     this.clipBehavior = Clip.hardEdge,
+    this.traversalEdgeBehavior,
   });
 
   /// Builds a [_DeclarativeAutoRouter] which uses
   /// a declarative list of routes to update navigator stack
   static Widget declarative({
     Key? key,
-    NavigatorObserversBuilder navigatorObservers =
-        AutoRouterDelegate.defaultNavigatorObserversBuilder,
+    NavigatorObserversBuilder navigatorObservers = AutoRouterDelegate.defaultNavigatorObserversBuilder,
     required RoutesBuilder routes,
     RoutePopCallBack? onPopRoute,
     String? navRestorationScopeId,
@@ -62,6 +64,7 @@ class AutoRouter extends StatefulWidget {
     OnNestedNavigateCallBack? onNavigate,
     WidgetBuilder? placeholder,
     Clip clipBehavior = Clip.hardEdge,
+    TraversalEdgeBehavior? traversalEdgeBehavior,
   }) =>
       _DeclarativeAutoRouter(
         onPopRoute: onPopRoute,
@@ -73,6 +76,7 @@ class AutoRouter extends StatefulWidget {
         placeholder: placeholder,
         routes: routes,
         clipBehavior: clipBehavior,
+        traversalEdgeBehavior: traversalEdgeBehavior,
       );
 
   @override
@@ -88,8 +92,7 @@ class AutoRouter extends StatefulWidget {
     var scope = StackRouterScope.of(context, watch: watch);
     assert(() {
       if (scope == null) {
-        throw FlutterError(
-            'AutoRouter operation requested with a context that does not include an AutoRouter.\n'
+        throw FlutterError('AutoRouter operation requested with a context that does not include an AutoRouter.\n'
             'The context used to retrieve the Router must be that of a widget that '
             'is a descendant of an AutoRouter widget.');
       }
@@ -166,6 +169,7 @@ class AutoRouterState extends State<AutoRouter> {
       navRestorationScopeId: widget.navRestorationScopeId,
       navigatorObservers: _navigatorObservers,
       placeholder: widget.placeholder,
+      routeTraversalEdgeBehavior: widget.traversalEdgeBehavior,
     );
     final stateHash = _controller!.stateHash;
     return RouterScope(
@@ -214,10 +218,10 @@ class _DeclarativeAutoRouter extends StatefulWidget {
   final OnNestedNavigateCallBack? onNavigate;
   final WidgetBuilder? placeholder;
   final Clip clipBehavior;
+  final TraversalEdgeBehavior? traversalEdgeBehavior;
   const _DeclarativeAutoRouter({
     required this.routes,
-    this.navigatorObservers =
-        AutoRouterDelegate.defaultNavigatorObserversBuilder,
+    this.navigatorObservers = AutoRouterDelegate.defaultNavigatorObserversBuilder,
     this.onPopRoute,
     this.navigatorKey,
     this.navRestorationScopeId,
@@ -225,6 +229,7 @@ class _DeclarativeAutoRouter extends StatefulWidget {
     this.onNavigate,
     this.placeholder,
     this.clipBehavior = Clip.hardEdge,
+    this.traversalEdgeBehavior,
   });
 
   @override
@@ -304,6 +309,7 @@ class _DeclarativeAutoRouterState extends State<_DeclarativeAutoRouter> {
           navigatorObservers: _navigatorObservers,
           didPop: widget.onPopRoute,
           placeholder: widget.placeholder,
+          routeTraversalEdgeBehavior: widget.traversalEdgeBehavior,
         ),
       ),
     );

--- a/auto_route/lib/src/router/widgets/auto_tabs_router.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_router.dart
@@ -468,7 +468,17 @@ class _IndexedStackBuilderState extends State<_IndexedStackBuilder> with _RouteA
             _initializedPagesTracker[index] = false;
           }
           final isInitialized = _initializedPagesTracker[index] == true;
-          return isInitialized ? widget.itemBuilder(context, index) : _dummyWidget;
+          final child = isInitialized ? widget.itemBuilder(context, index) : _dummyWidget;
+          final isInactive = index != widget.activeIndex;
+
+          // Always wrap with ExcludeSemantics and ExcludeFocus but control with excluding property
+          return ExcludeSemantics(
+            excluding: isInactive,
+            child: ExcludeFocus(
+              excluding: isInactive,
+              child: child,
+            ),
+          );
         },
       ),
     );

--- a/auto_route/pubspec.yaml
+++ b/auto_route/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_route
 description: AutoRoute is a declarative routing solution, where everything needed for navigation is automatically generated for you.
-version: 10.0.1
+version: 10.1.1
 homepage: https://github.com/Milad-Akarie/auto_route_library
 screenshots:
   - description: 'Auto Route Logo'


### PR DESCRIPTION
This PR introduces 2 changes.

1. Feat: Expose ` routeTraversalEdgeBehavior` from the underlying `Navigator`
2. Fix: When using the default `AutoTabRouter` (`IndexedStack` under the hood) the semantic and focus tree of invisible tabs was not excluded which effects focus traversal as it allows the focus to move to hidden tabs.