### PR TITLE
Fix: Allow PopCompleter to complete during route reevaluation

### DIFF
--- a/auto_route/lib/src/route/route_data.dart
+++ b/auto_route/lib/src/route/route_data.dart
@@ -221,8 +221,7 @@ class RouteData<R> {
   /// Completes the pop completer with the given result
   void onPopInvoked(R? result) {
     if (router.ignorePopCompleters) {
-      // if the route is re-evaluating or pop completers are ignored
-      // we don't complete the pop completer
+      // if pop completers are ignored then we don't complete the pop completer
       return;
     }
     if (_popCompleter != null && !_popCompleter!.isCompleted) {

--- a/auto_route/lib/src/route/route_data.dart
+++ b/auto_route/lib/src/route/route_data.dart
@@ -220,7 +220,7 @@ class RouteData<R> {
 
   /// Completes the pop completer with the given result
   void onPopInvoked(R? result) {
-    if (_isReevaluating || router.ignorePopCompleters) {
+    if (router.ignorePopCompleters) {
       // if the route is re-evaluating or pop completers are ignored
       // we don't complete the pop completer
       return;


### PR DESCRIPTION
This PR try to fix : https://github.com/Milad-Akarie/auto_route_library/issues/2206
It well fix the issue but i didn't know what can be the regression.

Hi @Milad-Akarie, what is the reason to not complete the popCompleter when _isReevaluating is true ?