### PR TITLE
Interprets bool/int/double as bool in optBool

### DIFF
--- a/auto_route/lib/src/common/parameters.dart
+++ b/auto_route/lib/src/common/parameters.dart
@@ -139,15 +139,15 @@ class Parameters {
 
     if (param == null) {
       return defaultValue;
+    } else if (param is bool) {
+      return param;
     } else if (param is int) {
       return param > 0;
     } else if (param is double) {
       return param > 0.0;
-    } else if (param is bool) {
-      return param;
     } else {
       //parse as string
-      switch (_params[key]?.toLowerCase()) {
+      switch (param.toLowerCase()) {
         case 'true':
           return true;
         case 'false':


### PR DESCRIPTION
Extends the `optBool` method to interpret integer and double values as booleans, aligning with Dart's truthiness behavior. This allows for more flexible parameter handling, where numeric values greater than zero are treated as true.