### PR TITLE
fix: meta import

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -11,6 +11,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:meta/meta.dart';
 
 part '../../route/route_data.dart';
 


### PR DESCRIPTION
The meta package import was missing in the routing_controller.dart file, so auto_route caused build errors.