### PR TITLE
fix: respect page.opaque for transparent route

### DIFF
--- a/auto_route/lib/src/router/auto_route_page.dart
+++ b/auto_route/lib/src/router/auto_route_page.dart
@@ -330,6 +330,9 @@ abstract class _PageRoute<T> extends PageRoute<T> {
   bool get allowSnapshotting => _page.allowSnapshotting;
 
   @override
+  bool get opaque => _page.opaque;
+
+  @override
   String get debugLabel => '${super.debugLabel}(${_page.name})';
 
   @override


### PR DESCRIPTION
### Summary
This PR fixes an issue where navigating to a route with `opaque: false` causes the background to turn black instead of showing the previous screen.

### Related Issues
- Fixes #2226
- Fixes #2205