### PR TITLE
enhance: appBarBuilder can return null

### DIFF
--- a/auto_route/lib/src/router/widgets/auto_tabs_scaffold.dart
+++ b/auto_route/lib/src/router/widgets/auto_tabs_scaffold.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 /// Signature for a function that takes in [BuildContext] and [TabsRouter]
 /// and returns a PreferredSizeWidget usually an AppBar
-typedef AppBarBuilder = PreferredSizeWidget Function(
+typedef AppBarBuilder = PreferredSizeWidget? Function(
   BuildContext context,
   TabsRouter tabsRouter,
 );


### PR DESCRIPTION
Th appBarBuilder should be able to return null based on the defined logic in the builder function. This gives more control/customisation.

```dart 
appBarBuilder: (context, tabsRouter) {
            if (tabsRouter.activeIndex != 0) {
              return null;
            }
            return AppBar(
              actions: const [
                NotificationsWidget(),
              ],
              backgroundColor: Colors.white,
              elevation: 0,
              scrolledUnderElevation: 0,
            );
          },
          ```