### PR TITLE
Fix WASM type mismatch.

### DIFF
--- a/auto_route/lib/src/router/controller/navigation_history/web_navigation_history.dart
+++ b/auto_route/lib/src/router/controller/navigation_history/web_navigation_history.dart
@@ -24,7 +24,10 @@ class NavigationHistoryImpl extends NavigationHistory {
   int get _currentIndex {
     final state = _history.state.dartify();
     if (state is Map) {
-      return state['serialCount'] ?? 0;
+      final serialCount = state['serialCount'];
+      if (serialCount is num) {
+        return serialCount.toInt();
+      }
     }
     return 0;
   }


### PR DESCRIPTION
I spent several hours today trying to figure out why our WASM Flutter web app was not loading. Finally narrowed it down to this line of code in our application:

```dart
if (AutoRouter.of(context).canNavigateBack)
```

This only seems to fail when I'm actually in WASM. I would get an error like this:

```
'minified:Class4694' in type cast
main.dart.mjs:73 at module0._TypeError._throwAsCheckError
```

Once I figured out where the issue was originating, I forked the repo and tested a solution. This fixes our code by getting more explicit about type checking and not using the dynamic type. I _think_ you could probably just push this through without much trouble.

Anyways, just reporting back for your benefit. Let me know if I can help further!