### PR TITLE
fix: correctly handle parameter names by removing leading underscores

### DIFF
--- a/auto_route_generator/lib/src/lean_builder/resolvers/lean_route_parameter_resolver.dart
+++ b/auto_route_generator/lib/src/lean_builder/resolvers/lean_route_parameter_resolver.dart
@@ -26,7 +26,10 @@ class LeanRouteParameterResolver {
       return _resolveFunctionType(parameterElement);
     }
     var type = _typeResolver.resolveType(paramType);
-    final paramName = parameterElement.name.replaceFirst("_", '');
+    var paramName = parameterElement.name;
+    if (paramName.startsWith('_')) {
+      paramName = paramName.replaceFirst("_", '');
+    }
     var pathParamObj = _pathParamChecker.firstAnnotationOfExact(parameterElement)?.constant as ConstObject?;
 
     var nameOrAlias = paramName;


### PR DESCRIPTION
Currently, the first underscore in the middle of a parameter name is removed from parameter names. E.g parameter name "access_token" is converted to "accesstoken"

This PR makes the assumption that what the original code was actually trying to do is to remove **leading** underscores.