### PR TITLE
fix: correctly handle parameter names by removing leading underscores

### DIFF
--- a/auto_route_generator/lib/src/resolvers/route_parameter_resolver.dart
+++ b/auto_route_generator/lib/src/resolvers/route_parameter_resolver.dart
@@ -26,7 +26,10 @@ class RouteParameterResolver {
       return _resolveFunctionType(parameterElement);
     }
     var type = _typeResolver.resolveType(paramType);
-    final paramName = parameterElement.displayName.replaceFirst("_", '');
+    var paramName = parameterElement.name;
+    if (paramName.startsWith('_')) {
+      paramName = paramName.replaceFirst("_", '');
+    }
     var pathParamAnnotation = _pathParamChecker.firstAnnotationOfExact(parameterElement);
 
     var nameOrAlias = paramName;


### PR DESCRIPTION
This PR adds the same fix for the parameter resolver as in PR #2285