### PR TITLE
fix: notify all listeners on page pop to ensure consistent state updates

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -1252,9 +1252,7 @@ abstract class StackRouter extends RoutingController {
   void onPopPage(AutoRoutePage<Object?> page) {
     if (!_pages.remove(page)) return;
     _updateSharedPathData(includeAncestors: true);
-    if (isRouteDataActive(page.routeData)) {
-      navigationHistory.rebuildUrl();
-    }
+    notifyAll(forceUrlRebuild: true);
   }
 
   void _removeRoute(RouteMatch route, {bool notify = true}) {


### PR DESCRIPTION
Closes #2311

## Issue
In v9, onPopPage called removeRoute() → _removeRoute() → notifyAll(forceUrlRebuild: true),      
  which:                                                                                          
  - Called notifyListeners() on the StackRouter (triggering UI rebuilds)                          
  - Called navigationHistory.rebuildUrl() unconditionally (updating the URL)                      
  - Called _removeTopRouterOf(route.key) (cleaning up child controllers)                          
                                                                                                  
  In v10+, onPopPage was refactored to:                                                           
                                                                                                  
  void onPopPage(AutoRoutePage<Object?> page) {                                                   
      if (!_pages.remove(page)) return;                                                           
      _updateSharedPathData(includeAncestors: true);                                              
      if (isRouteDataActive(page.routeData)) {                                                    
        navigationHistory.rebuildUrl();                                                           
      }                                                                                           
  }

## This has two problems:                                                                          
                                                                                                  
  1. notifyListeners() is never called — StackRouter listeners never fire on pop, so any UI       
  depending on route changes (like bottom nav visibility) doesn't rebuild.                        
  2. rebuildUrl() is conditional on isRouteDataActive(), which compares the popped route's        
  RouteMatch against current URL state segments using RouteMatch.==. This equality check includes 
  params, stringMatch, key, etc. With path parameters (e.g., /patients/:id), the match object from
   the popped page may not compare equal to the stale URL state segment, causing rebuildUrl() to  
  be skipped entirely.                                                                            
                                                                                                  
  ## Fix                                                                                             
                                                                                                  
  Replace the conditional rebuildUrl() with notifyAll(forceUrlRebuild: true), restoring the v9    
  behavior:                                                                                       
                                                                                                  
  void onPopPage(AutoRoutePage<Object?> page) {                                                   
      if (!_pages.remove(page)) return;                                                           
      _updateSharedPathData(includeAncestors: true);                                              
      notifyAll(forceUrlRebuild: true);                                                           
  }                                                                                               
                                                                                                  
  notifyAll(forceUrlRebuild: true) handles both missing pieces:                                   
  - Calls notifyListeners() so router listeners fire and UI rebuilds                              
  - Unconditionally rebuilds the URL so it reflects the correct route after pop                   
                                                                                           