### PR TITLE
fix: create mutable copy of pendingChildren in _onStartReevaluating

### DIFF
--- a/auto_route/lib/src/route/route_data.dart
+++ b/auto_route/lib/src/route/route_data.dart
@@ -212,7 +212,7 @@ class RouteData<R> {
   void _onStartReevaluating(RouteMatch newMatch) {
     _isReevaluating = true;
     _updateRoute(newMatch);
-    _pendingChildren = newMatch.children ?? [];
+    _pendingChildren = List<RouteMatch>.from(newMatch.children ?? []);
   }
 
   void _onEndReevaluating(RouteMatch newMatch) {


### PR DESCRIPTION
## Summary

- Fix crash: `UnmodifiableListMixin.clear` — "Unsupported operation: Cannot clear an unmodifiable list"
- The `_onStartReevaluating` method in `route_data.dart` directly assigns `newMatch.children` to `_pendingChildren`, which can be an unmodifiable list (e.g. `const []` from `routing_controller.dart:836`)
- When `TabsRouter.setupRoutes()` later calls `_routeData.pendingChildren.clear()`, it crashes

## Fix

Wrap the assignment with `List<RouteMatch>.from()` to create a mutable copy, matching the pattern already used in the `RouteData` constructor at line 48:

```dart
// Before
_pendingChildren = newMatch.children ?? [];

// After
_pendingChildren = List<RouteMatch>.from(newMatch.children ?? []);
```

## Stack trace from Crashlytics

```
Fatal Exception: FlutterError
Unsupported operation: Cannot clear an unmodifiable list

0  dart:_internal              UnmodifiableListMixin.clear
1  routing_controller.dart:793 TabsRouter.setupRoutes
2  auto_tabs_router.dart:652   _AutoTabsRouterTabBarState._setupController
3  auto_tabs_router.dart:201   AutoTabsRouterState.didChangeDependencies
```

## Impact

149 crash events affecting 27 users over 7 days in production (auto_route 10.3.0).

## Test plan

- [x] Verified `dart analyze` passes with no new issues
- [ ] Navigate between tabs to trigger `didChangeDependencies` / route reevaluation
- [ ] Confirm no crash on tab switching after state changes