### PR TITLE
Flutter Web: make browser history adjusted properly if pop() was called in the code. And improved issue with lost query parameters during the Back navigation.

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -1184,8 +1184,10 @@ abstract class StackRouter extends RoutingController {
   @override
   RouteData get topRoute => _topMostRouter(ignorePagelessRoutes: true).current;
 
+  bool _fakeReportNoPagelessTopRoute = false;
+
   /// Whether the top-most route of this controller is page-less
-  bool get hasPagelessTopRoute => pagelessRoutesObserver.hasPagelessTopRoute;
+  bool get hasPagelessTopRoute => pagelessRoutesObserver.hasPagelessTopRoute && !_fakeReportNoPagelessTopRoute;
 
   @override
   void _updateSharedPathData({
@@ -1251,10 +1253,34 @@ abstract class StackRouter extends RoutingController {
   /// that does not use [PageRoute] will not trigger this method
   void onPopPage(AutoRoutePage<Object?> page) {
     if (!_pages.remove(page)) return;
-    _updateSharedPathData(includeAncestors: true);
-    if (isRouteDataActive(page.routeData)) {
-      navigationHistory.rebuildUrl();
+    Map<String, dynamic> newQueryParams = {};
+    if (_pages.isNotEmpty) {
+      newQueryParams = getNewQueryParamsAfterPop(_pages.last, page) ?? {};
     }
+    _updateSharedPathData(includeAncestors: true, queryParams: newQueryParams);
+    if (isRouteDataActive(page.routeData)) {
+      if (navigationHistory.canNavigateBack && !navigationHistory.isUrlStateMarkedForReplace) {
+        // See https://github.com/Milad-Akarie/auto_route_library/issues/1839
+        navigationHistory.rebuildUrl();
+        final st = navigationHistory.urlState.copyWith();
+        // preserving PagelessTopRoute from closing by back() -> AutoRouterDelegate.setNewRoutePath()
+        _fakeReportNoPagelessTopRoute = true;
+        navigationHistory.back();
+        // back() could be async operation (on web it is always async), so we have to wait till it's done
+        Future.delayed(Duration(milliseconds: 200), () {
+          _fakeReportNoPagelessTopRoute = false;
+          if (navigationHistory.urlState.uri != st.uri) {
+            navigationHistory.onNewUrlState(st);
+          }
+        });
+      } else {
+        navigationHistory.rebuildUrl();
+      }
+    }
+  }
+
+  Map<String, dynamic>? getNewQueryParamsAfterPop(AutoRoutePage<Object?> newPage, AutoRoutePage<Object?> oldPage) {
+    return null;
   }
 
   void _removeRoute(RouteMatch route, {bool notify = true}) {


### PR DESCRIPTION
See https://github.com/Milad-Akarie/auto_route_library/issues/1839#issuecomment-3846108911