### PR TITLE
feat: Add ParamConverter for @PathParam / @QueryParam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,57 @@ class BookDetailsPage extends StatelessWidget {
 }
 ```
 
+### Custom Parameter Converters
+
+Out of the box `@PathParam` and `@QueryParam` support `String`, `int`, `double`, `num`, `bool`, and `List<String>`. For any other type (enums, `DateTime`, custom value types), supply a `ParamConverter<T>`. It handles both directions: `fromParam` parses an incoming URL, `toParam` serializes the typed value when a route is built in code.
+
+#### Enums (auto-detected)
+
+If the parameter type is an `enum`, **AutoRoute** generates a converter automatically. No extra annotation argument is needed.
+
+```dart
+enum Filter { all, active, archived }
+
+@RoutePage()
+class TasksPage extends StatelessWidget {
+  const TasksPage({@queryParam this.filter = Filter.all});
+  final Filter filter;
+}
+```
+
+Matching is by `Enum.name` in both directions: `TasksRoute(filter: Filter.active)` writes `?filter=active`, and `/tasks?filter=active` parses back to `Filter.active`.
+
+#### Custom types
+
+For non-enum types, extend `ParamConverter<T>`, implement both `fromParam` and `toParam`, and pass a top-level `const` instance to the annotation:
+
+```dart
+class DateConverter extends ParamConverter<DateTime> {
+  const DateConverter();
+
+  @override
+  DateTime fromParam(String? value) => DateTime.parse(value!);
+
+  @override
+  String toParam(DateTime value) =>
+      '${value.year.toString().padLeft(4, '0')}-'
+      '${value.month.toString().padLeft(2, '0')}-'
+      '${value.day.toString().padLeft(2, '0')}';
+}
+
+const dateConverter = DateConverter();
+
+@RoutePage()
+class EventPage extends StatelessWidget {
+  const EventPage({
+    @QueryParam('date', dateConverter) this.date,
+  });
+  final DateTime? date;
+}
+```
+
+`toParam` must be the inverse of `fromParam` so URLs round-trip. Returning `null` (or passing `null` for a nullable param) drops the key from the outgoing URL. The converter must be a top-level `const` variable; inline `const` expressions are rejected by the generator. Parsing errors fall back to the `defaultValue` (matching `optInt`/`optDouble` behaviour), so malformed URLs do not crash navigation.
+
 ### Redirecting Paths
 
 Paths can be redirected using `RedirectRoute`. The following setup will navigate us to `/books` when `/` is matched.

--- a/auto_route/CHANGELOG.md
+++ b/auto_route/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- **FEAT**: bi-directional custom `@PathParam` / `@QueryParam` conversion via `ParamConverter<T>` (`fromParam` + `toParam`); enum params auto-detected and round-trip by `Enum.name`. #2148
+
 ## 11.1.0
 - **CHORE:** deprecate animatePageTransition #2301
 - **Enhance:** add .named constructor to PageRouteInfo and AutoRoute to enable usage for shorthand

--- a/auto_route/lib/annotations.dart
+++ b/auto_route/lib/annotations.dart
@@ -1,1 +1,2 @@
 export 'src/common/auto_route_annotations.dart';
+export 'src/common/param_converter.dart';

--- a/auto_route/lib/src/common/auto_route_annotations.dart
+++ b/auto_route/lib/src/common/auto_route_annotations.dart
@@ -1,6 +1,8 @@
 import 'package:meta/meta.dart' show optionalTypeArgs;
 import 'package:meta/meta_meta.dart' show Target, TargetKind;
 
+import 'param_converter.dart';
+
 /// Classes annotated with AutoRouteConfig will generate
 /// an abstract class that extends [RootStackRouter] that
 /// can be extended by the annotated class to be used as the RootRouter of the App
@@ -82,15 +84,22 @@ class PathParam {
   /// (@PathParam() int id); -> name = id
   final String? name;
 
+  /// optional [ParamConverter] used to convert the raw path segment into
+  /// the parameter's typed value (and back when the route is built in code)
+  ///
+  /// required for non-primitive, non-enum types; must reference a top-level
+  /// `const` variable (inline `const` expressions are rejected)
+  final ParamConverter? converter;
+
   // ignore: unused_field
   final bool _inherited;
 
   /// default constructor
-  const PathParam([this.name]) : _inherited = false;
+  const PathParam([this.name, this.converter]) : _inherited = false;
 
   /// Use this constructor to inherit a dynamic-segment
   /// from a parent path
-  const PathParam.inherit([this.name]) : _inherited = true;
+  const PathParam.inherit([this.name, this.converter]) : _inherited = true;
 }
 
 /// default PathParam()
@@ -111,8 +120,15 @@ class QueryParam {
   /// (@QueryParam() String foo); -> name = foo
   final String? name;
 
+  /// optional [ParamConverter] used to convert the raw query string into
+  /// the parameter's typed value (and back when the route is built in code)
+  ///
+  /// required for non-primitive, non-enum types; must reference a top-level
+  /// `const` variable (inline `const` expressions are rejected)
+  final ParamConverter? converter;
+
   /// default constructor
-  const QueryParam([this.name]);
+  const QueryParam([this.name, this.converter]);
 }
 
 /// default QueryParam()

--- a/auto_route/lib/src/common/common.dart
+++ b/auto_route/lib/src/common/common.dart
@@ -1,5 +1,6 @@
 export 'auto_route_annotations.dart';
 export 'auto_route_wrapper.dart';
+export 'param_converter.dart';
 export 'parameters.dart';
 export 'transitions_builders.dart';
 export 'auto_route_observer.dart';

--- a/auto_route/lib/src/common/param_converter.dart
+++ b/auto_route/lib/src/common/param_converter.dart
@@ -32,8 +32,6 @@
 /// for [Enum] types the generator auto-injects [EnumParamConverter], so
 /// no explicit converter is required on the annotation
 abstract class ParamConverter<T> {
-  /// const constructor; subclasses must invoke this so instances can be used
-  /// in annotations
   const ParamConverter();
 
   /// converts a raw URL string [value] (or `null` when absent) into a value
@@ -63,7 +61,6 @@ class EnumParamConverter<T extends Enum> extends ParamConverter<T> {
   /// full list of enum values for [T]; pass `Foo.values`
   final List<T> values;
 
-  /// default const constructor
   const EnumParamConverter(this.values) : super();
 
   /// shared name -> value lookup, keyed by [values] identity so different

--- a/auto_route/lib/src/common/param_converter.dart
+++ b/auto_route/lib/src/common/param_converter.dart
@@ -1,0 +1,88 @@
+/// contract for converting between URL parameter strings and typed values
+///
+/// implementations must have a `const` constructor so an instance can be
+/// passed as an annotation argument, e.g. `@QueryParam('date', dateConverter)`
+///
+/// declare a top-level `const` variable for the converter and reference it
+/// from the annotation:
+///
+/// ```dart
+/// class DateConverter extends ParamConverter<DateTime> {
+///   const DateConverter();
+///
+///   @override
+///   DateTime fromParam(String? value) => DateTime.parse(value!);
+///
+///   @override
+///   String toParam(DateTime value) =>
+///       '${value.year}-${value.month}-${value.day}';
+/// }
+///
+/// const dateConverter = DateConverter();
+///
+/// @RoutePage()
+/// class EventPage extends StatelessWidget {
+///   const EventPage({
+///     @QueryParam('date', dateConverter) required this.date,
+///   });
+///   final DateTime date;
+/// }
+/// ```
+///
+/// for [Enum] types the generator auto-injects [EnumParamConverter], so
+/// no explicit converter is required on the annotation
+abstract class ParamConverter<T> {
+  /// const constructor; subclasses must invoke this so instances can be used
+  /// in annotations
+  const ParamConverter();
+
+  /// converts a raw URL string [value] (or `null` when absent) into a value
+  /// of type [T]
+  ///
+  /// implementations should throw if [value] is non-null but cannot be parsed;
+  /// [Parameters.optTyped] catches such exceptions and falls back to the default
+  T fromParam(String? value);
+
+  /// converts [value] into the URL string emitted by the generator when a
+  /// route is constructed programmatically (e.g. `MyRoute(date: ...)`)
+  ///
+  /// should be the inverse of [fromParam]; returning `null` drops the param
+  /// from query strings and substitutes empty in path segments
+  String? toParam(T value);
+}
+
+/// built-in [ParamConverter] for any [Enum] type
+///
+/// the generator emits `const EnumParamConverter<Foo>(Foo.values)`
+/// automatically when it sees `@PathParam` / `@QueryParam` on an enum-typed
+/// parameter, so users rarely use this class directly
+///
+/// matching is by [Enum.name] (case-sensitive); throws [StateError] when no
+/// value matches
+class EnumParamConverter<T extends Enum> extends ParamConverter<T> {
+  /// full list of enum values for [T]; pass `Foo.values`
+  final List<T> values;
+
+  /// default const constructor
+  const EnumParamConverter(this.values) : super();
+
+  /// shared name -> value lookup, keyed by [values] identity so different
+  /// lists (subsets, hot-reloaded `Foo.values`) get their own entries
+  static final Map<List<Enum>, Map<String, Enum>> _byName = Map.identity();
+
+  @override
+  T fromParam(String? value) {
+    final lookup = _byName.putIfAbsent(
+      values,
+      () => {for (final v in values) v.name: v},
+    );
+    final hit = lookup[value];
+    if (hit == null) {
+      throw StateError('No element');
+    }
+    return hit as T;
+  }
+
+  @override
+  String toParam(T value) => value.name;
+}

--- a/auto_route/lib/src/common/parameters.dart
+++ b/auto_route/lib/src/common/parameters.dart
@@ -1,6 +1,8 @@
 import 'package:auto_route/src/route/errors.dart';
 import 'package:collection/collection.dart';
 
+import 'param_converter.dart';
+
 /// This class helps read typed data from
 /// raw maps, it's used for both path-parameters and query-parameters
 class Parameters {
@@ -149,6 +151,30 @@ class Parameters {
     var val = optBool(key, defaultValue);
     if (val == null) {
       throw MissingRequiredParameterError('Failed to parse [bool] $key value from ${_params[key]}');
+    }
+    return val;
+  }
+
+  /// returns the value corresponding with [key] converted via [converter]
+  /// as nullable [T]
+  /// if null or the converter throws, returns [defaultValue]
+  T? optTyped<T>(String key, ParamConverter<T> converter, [T? defaultValue]) {
+    final raw = _params[key];
+    if (raw == null) return defaultValue;
+    try {
+      return converter.fromParam(raw.toString());
+    } catch (_) {
+      return defaultValue;
+    }
+  }
+
+  /// returns the value corresponding with [key] converted via [converter]
+  /// as [T]
+  /// if null returns [defaultValue]
+  T getTyped<T>(String key, ParamConverter<T> converter, [T? defaultValue]) {
+    final val = optTyped<T>(key, converter, defaultValue);
+    if (val == null) {
+      throw MissingRequiredParameterError('Failed to parse [$T] $key value from ${_params[key]}');
     }
     return val;
   }

--- a/auto_route/test/annotations/auto_route_annotations_test.dart
+++ b/auto_route/test/annotations/auto_route_annotations_test.dart
@@ -43,16 +43,31 @@ void main() {
     test('default constructor', () {
       const param = PathParam();
       expect(param.name, null);
+      expect(param.converter, null);
     });
 
     test('named constructor', () {
       const param = PathParam('id');
       expect(param.name, 'id');
+      expect(param.converter, null);
     });
 
     test('inherit constructor', () {
       const param = PathParam.inherit('id');
       expect(param.name, 'id');
+      expect(param.converter, null);
+    });
+
+    test('constructor with converter', () {
+      const param = PathParam('color', _colorConverter);
+      expect(param.name, 'color');
+      expect(param.converter, same(_colorConverter));
+    });
+
+    test('inherit constructor with converter', () {
+      const param = PathParam.inherit('color', _colorConverter);
+      expect(param.name, 'color');
+      expect(param.converter, same(_colorConverter));
     });
   });
 
@@ -60,11 +75,19 @@ void main() {
     test('default constructor', () {
       const param = QueryParam();
       expect(param.name, null);
+      expect(param.converter, null);
     });
 
     test('named constructor', () {
       const param = QueryParam('foo');
       expect(param.name, 'foo');
+      expect(param.converter, null);
+    });
+
+    test('constructor with converter', () {
+      const param = QueryParam('color', _colorConverter);
+      expect(param.name, 'color');
+      expect(param.converter, same(_colorConverter));
     });
   });
 
@@ -75,3 +98,7 @@ void main() {
     });
   });
 }
+
+enum _Color { red, green, blue }
+
+const _colorConverter = EnumParamConverter<_Color>(_Color.values);

--- a/auto_route/test/main_router.gr.dart
+++ b/auto_route/test/main_router.gr.dart
@@ -11,6 +11,58 @@
 part of 'main_router.dart';
 
 /// generated route for
+/// [DatePage]
+class DateRoute extends PageRouteInfo<DateRouteArgs> {
+  DateRoute({Key? key, TestDate? date, List<PageRouteInfo>? children})
+      : super(
+          DateRoute.name,
+          args: DateRouteArgs(key: key, date: date),
+          rawQueryParams: {
+            'date': date == null ? null : testDateConverter.toParam(date),
+          },
+          initialChildren: children,
+        );
+
+  static const String name = 'DateRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final queryParams = data.queryParams;
+      final args = data.argsAs<DateRouteArgs>(
+        orElse: () => DateRouteArgs(
+          date: queryParams.optTyped<TestDate>('date', testDateConverter),
+        ),
+      );
+      return DatePage(key: args.key, date: args.date);
+    },
+  );
+}
+
+class DateRouteArgs {
+  const DateRouteArgs({this.key, this.date});
+
+  final Key? key;
+
+  final TestDate? date;
+
+  @override
+  String toString() {
+    return 'DateRouteArgs{key: $key, date: $date}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! DateRouteArgs) return false;
+    return key == other.key && date == other.date;
+  }
+
+  @override
+  int get hashCode => key.hashCode ^ date.hashCode;
+}
+
+/// generated route for
 /// [DeclarativeRouterHostScreen]
 class DeclarativeRouterHostRoute extends PageRouteInfo<DeclarativeRouterHostRouteArgs> {
   DeclarativeRouterHostRoute({
@@ -61,6 +113,116 @@ class DeclarativeRouterHostRouteArgs {
 
   @override
   int get hashCode => key.hashCode ^ pageNotifier.hashCode;
+}
+
+/// generated route for
+/// [EnumPathPage]
+class EnumPathRoute extends PageRouteInfo<EnumPathRouteArgs> {
+  EnumPathRoute({
+    Key? key,
+    TestColor color = TestColor.red,
+    List<PageRouteInfo>? children,
+  }) : super(
+          EnumPathRoute.name,
+          args: EnumPathRouteArgs(key: key, color: color),
+          rawPathParams: {'color': color.name},
+          initialChildren: children,
+        );
+
+  static const String name = 'EnumPathRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final pathParams = data.inheritedPathParams;
+      final args = data.argsAs<EnumPathRouteArgs>(
+        orElse: () => EnumPathRouteArgs(
+          color: pathParams.getTyped<TestColor>(
+            'color',
+            const EnumParamConverter<TestColor>(TestColor.values),
+            TestColor.red,
+          ),
+        ),
+      );
+      return EnumPathPage(key: args.key, color: args.color);
+    },
+  );
+}
+
+class EnumPathRouteArgs {
+  const EnumPathRouteArgs({this.key, this.color = TestColor.red});
+
+  final Key? key;
+
+  final TestColor color;
+
+  @override
+  String toString() {
+    return 'EnumPathRouteArgs{key: $key, color: $color}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! EnumPathRouteArgs) return false;
+    return key == other.key && color == other.color;
+  }
+
+  @override
+  int get hashCode => key.hashCode ^ color.hashCode;
+}
+
+/// generated route for
+/// [EnumQueryPage]
+class EnumQueryRoute extends PageRouteInfo<EnumQueryRouteArgs> {
+  EnumQueryRoute({Key? key, TestColor? color, List<PageRouteInfo>? children})
+      : super(
+          EnumQueryRoute.name,
+          args: EnumQueryRouteArgs(key: key, color: color),
+          rawQueryParams: {'color': color == null ? null : color.name},
+          initialChildren: children,
+        );
+
+  static const String name = 'EnumQueryRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      final queryParams = data.queryParams;
+      final args = data.argsAs<EnumQueryRouteArgs>(
+        orElse: () => EnumQueryRouteArgs(
+          color: queryParams.optTyped<TestColor>(
+            'color',
+            const EnumParamConverter<TestColor>(TestColor.values),
+          ),
+        ),
+      );
+      return EnumQueryPage(key: args.key, color: args.color);
+    },
+  );
+}
+
+class EnumQueryRouteArgs {
+  const EnumQueryRouteArgs({this.key, this.color});
+
+  final Key? key;
+
+  final TestColor? color;
+
+  @override
+  String toString() {
+    return 'EnumQueryRouteArgs{key: $key, color: $color}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! EnumQueryRouteArgs) return false;
+    return key == other.key && color == other.color;
+  }
+
+  @override
+  int get hashCode => key.hashCode ^ color.hashCode;
 }
 
 /// generated route for

--- a/auto_route/test/param_converter_test.dart
+++ b/auto_route/test/param_converter_test.dart
@@ -1,0 +1,159 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+enum _Color { red, green, blue }
+
+const _colorConverter = EnumParamConverter<_Color>(_Color.values);
+
+class _DateConverter extends ParamConverter<DateTime> {
+  const _DateConverter();
+
+  @override
+  DateTime fromParam(String? value) => DateTime.parse(value!);
+
+  @override
+  String toParam(DateTime value) =>
+      '${value.year.toString().padLeft(4, '0')}-'
+      '${value.month.toString().padLeft(2, '0')}-'
+      '${value.day.toString().padLeft(2, '0')}';
+}
+
+const _dateConverter = _DateConverter();
+
+void main() {
+  group('EnumParamConverter', () {
+    test('parses by enum name', () {
+      expect(_colorConverter.fromParam('red'), _Color.red);
+      expect(_colorConverter.fromParam('green'), _Color.green);
+      expect(_colorConverter.fromParam('blue'), _Color.blue);
+    });
+
+    test('throws StateError on unknown name', () {
+      expect(
+        () => _colorConverter.fromParam('purple'),
+        throwsStateError,
+      );
+    });
+
+    test('throws StateError on null', () {
+      expect(
+        () => _colorConverter.fromParam(null),
+        throwsStateError,
+      );
+    });
+
+    test('serializes by enum name', () {
+      expect(_colorConverter.toParam(_Color.red), 'red');
+      expect(_colorConverter.toParam(_Color.green), 'green');
+      expect(_colorConverter.toParam(_Color.blue), 'blue');
+    });
+
+    test('round-trips through fromParam/toParam', () {
+      for (final c in _Color.values) {
+        expect(_colorConverter.fromParam(_colorConverter.toParam(c)), c);
+      }
+    });
+  });
+
+  group('ParamConverter subclass', () {
+    test('user-defined converter parses successfully', () {
+      expect(
+        _dateConverter.fromParam('2026-05-14'),
+        DateTime(2026, 5, 14),
+      );
+    });
+
+    test('user-defined converter rethrows on bad input', () {
+      expect(
+        () => _dateConverter.fromParam('not-a-date'),
+        throwsFormatException,
+      );
+    });
+
+    test('user-defined converter serializes', () {
+      expect(_dateConverter.toParam(DateTime(2026, 5, 14)), '2026-05-14');
+    });
+
+    test('round-trips through fromParam/toParam', () {
+      final original = DateTime(2026, 5, 14);
+      expect(
+        _dateConverter.fromParam(_dateConverter.toParam(original)),
+        original,
+      );
+    });
+  });
+
+  group('Parameters.optTyped', () {
+    test('returns converted value when key is present', () {
+      const params = Parameters({'c': 'red'});
+      expect(params.optTyped<_Color>('c', _colorConverter), _Color.red);
+    });
+
+    test('returns null when key is absent', () {
+      const params = Parameters({});
+      expect(params.optTyped<_Color>('c', _colorConverter), null);
+    });
+
+    test('returns defaultValue when key is absent', () {
+      const params = Parameters({});
+      expect(
+        params.optTyped<_Color>('c', _colorConverter, _Color.blue),
+        _Color.blue,
+      );
+    });
+
+    test(
+        'silently returns defaultValue when converter throws '
+        '(matches optInt/optDouble fallback)', () {
+      const params = Parameters({'c': 'not-a-color'});
+      expect(
+        params.optTyped<_Color>('c', _colorConverter, _Color.green),
+        _Color.green,
+      );
+    });
+
+    test('silently returns null when converter throws and no default', () {
+      const params = Parameters({'c': 'not-a-color'});
+      expect(params.optTyped<_Color>('c', _colorConverter), null);
+    });
+  });
+
+  group('Parameters.getTyped', () {
+    test('returns converted value when key is present', () {
+      const params = Parameters({'c': 'red'});
+      expect(params.getTyped<_Color>('c', _colorConverter), _Color.red);
+    });
+
+    test('throws MissingRequiredParameterError when key is absent', () {
+      const params = Parameters({});
+      expect(
+        () => params.getTyped<_Color>('c', _colorConverter),
+        throwsFlutterError,
+      );
+    });
+
+    test('returns defaultValue when key is absent', () {
+      const params = Parameters({});
+      expect(
+        params.getTyped<_Color>('c', _colorConverter, _Color.red),
+        _Color.red,
+      );
+    });
+
+    test('throws when converter fails and no defaultValue is supplied', () {
+      const params = Parameters({'c': 'bogus'});
+      expect(
+        () => params.getTyped<_Color>('c', _colorConverter),
+        throwsFlutterError,
+      );
+    });
+
+    test('returns defaultValue when converter fails', () {
+      const params = Parameters({'c': 'bogus'});
+      expect(
+        params.getTyped<_Color>('c', _colorConverter, _Color.blue),
+        _Color.blue,
+      );
+    });
+  });
+}

--- a/auto_route/test/route_param_serialization_test.dart
+++ b/auto_route/test/route_param_serialization_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'main_router.dart';
+import 'test_page.dart';
+
+void main() {
+  group('generated routes serialize typed params via ParamConverter.toParam', () {
+    test('enum path param stringifies by name', () {
+      final route = EnumPathRoute(color: TestColor.green);
+      expect(route.rawPathParams['color'], 'green');
+    });
+
+    test('enum query param stringifies by name', () {
+      final route = EnumQueryRoute(color: TestColor.blue);
+      expect(route.rawQueryParams['color'], 'blue');
+    });
+
+    test('null enum query param stays null', () {
+      final route = EnumQueryRoute(color: null);
+      expect(route.rawQueryParams['color'], null);
+    });
+
+    test('custom type uses user-defined toParam', () {
+      final route = DateRoute(date: const TestDate(2026, 5, 14));
+      expect(route.rawQueryParams['date'], '2026-5-14');
+    });
+
+    test('null custom type stays null', () {
+      final route = DateRoute(date: null);
+      expect(route.rawQueryParams['date'], null);
+    });
+  });
+}

--- a/auto_route/test/simple_router/router.dart
+++ b/auto_route/test/simple_router/router.dart
@@ -14,5 +14,8 @@ class SimpleRouter extends MainRouter {
         AutoRouteGuard.simple((resolver, _) => resolver.next(false)),
       ],
     ),
+    AutoRoute(page: EnumPathRoute.page, path: '/color/:color'),
+    AutoRoute(page: EnumQueryRoute.page, path: '/enum-query'),
+    AutoRoute(page: DateRoute.page, path: '/date'),
   ];
 }

--- a/auto_route/test/test_page.dart
+++ b/auto_route/test/test_page.dart
@@ -201,3 +201,64 @@ class DeclarativeRouterHostScreen extends StatelessWidget {
     );
   }
 }
+
+/// sample enum exercising the auto-detected enum converter code path
+enum TestColor { red, green, blue }
+
+@RoutePage()
+class EnumPathPage extends TestPage {
+  const EnumPathPage({super.key, @pathParam this.color = TestColor.red});
+
+  final TestColor color;
+}
+
+@RoutePage()
+class EnumQueryPage extends TestPage {
+  const EnumQueryPage({super.key, @queryParam this.color});
+
+  final TestColor? color;
+}
+
+/// custom value type used by [DatePage]
+class TestDate {
+  final int year;
+  final int month;
+  final int day;
+  const TestDate(this.year, this.month, this.day);
+
+  @override
+  bool operator ==(Object other) => other is TestDate && other.year == year && other.month == month && other.day == day;
+
+  @override
+  int get hashCode => Object.hash(year, month, day);
+}
+
+/// user-supplied [ParamConverter] used by [DatePage]
+class TestDateConverter extends ParamConverter<TestDate> {
+  const TestDateConverter();
+
+  @override
+  TestDate fromParam(String? value) {
+    final parts = value!.split('-');
+    return TestDate(
+      int.parse(parts[0]),
+      int.parse(parts[1]),
+      int.parse(parts[2]),
+    );
+  }
+
+  @override
+  String toParam(TestDate value) => '${value.year}-${value.month}-${value.day}';
+}
+
+const testDateConverter = TestDateConverter();
+
+@RoutePage()
+class DatePage extends TestPage {
+  const DatePage({
+    super.key,
+    @QueryParam('date', testDateConverter) this.date,
+  });
+
+  final TestDate? date;
+}

--- a/auto_route_generator/CHANGELOG.md
+++ b/auto_route_generator/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- **FEAT**: read `converter:` on `@PathParam` / `@QueryParam` and auto-detect enums; emit `getTyped<T>` / `optTyped<T>` for incoming URLs and `toParam(...)` in `rawPathParams` / `rawQueryParams` for outgoing routes. #2148
+
 ## 10.5.0
 - **CHORE**: update analyzer constrains to include version 10.0.0
 ## 10.4.0

--- a/auto_route_generator/lib/src/code_builder/route_info_builder.dart
+++ b/auto_route_generator/lib/src/code_builder/route_info_builder.dart
@@ -92,7 +92,7 @@ List<Class> buildRouteInfoAndArgs(RouteConfig r, RouterConfig router, DartEmitte
                           nonInheritedParameters.where((p) => p.isPathParam).map(
                                 (p) => MapEntry(
                                   p.paramName,
-                                  refer(p.name),
+                                  _rawParamValue(p),
                                 ),
                               ),
                         ),
@@ -103,7 +103,7 @@ List<Class> buildRouteInfoAndArgs(RouteConfig r, RouterConfig router, DartEmitte
                           parameters.where((p) => p.isQueryParam).map(
                                 (p) => MapEntry(
                                   p.paramName,
-                                  refer(p.name),
+                                  _rawParamValue(p),
                                 ),
                               ),
                         ),
@@ -378,19 +378,62 @@ Expression _getPageInstance(RouteConfig r) {
 }
 
 Expression _getUrlPartAssignment(ParamConfig p) {
-  if (p.isPathParam) {
-    return refer('pathParams').property(p.getterMethodName).call([
-      literalString(p.paramName),
-      if (p.defaultValueCode != null) refer(p.defaultValueCode!),
-    ]);
-  } else if (p.isQueryParam) {
-    return refer('queryParams').property(p.getterMethodName).call([
-      literalString(p.paramName),
-      if (p.defaultValueCode != null) refer(p.defaultValueCode!),
-    ]);
-  } else {
+  if (p.isUrlFragment || (!p.isPathParam && !p.isQueryParam)) {
     return refer('data').property('fragment');
   }
+  final paramsRef = p.isPathParam ? refer('pathParams') : refer('queryParams');
+  final args = <Expression>[
+    literalString(p.paramName),
+    if (p.hasConverter) _buildConverterRef(p),
+    if (p.defaultValueCode != null) refer(p.defaultValueCode!),
+  ];
+
+  final methodRef = paramsRef.property(p.getterMethodName); // e.g. queryParams.getTyped
+  if (p.hasConverter) {
+    // T is always non-nullable; optTyped<T> already returns T?
+    return InvokeExpression.newOf(
+      methodRef,
+      args,
+      const {},
+      [_nonNullableRefer(p.type)],
+    );
+  }
+  return methodRef.call(args);
+}
+
+TypeReference _nonNullableRefer(ResolvedType type) => TypeReference((b) => b
+  ..symbol = type.name
+  ..url = type.import
+  ..types.addAll(type.typeArguments.map((e) => e.refer)));
+
+/// Builds the value expression for [p] in `rawPathParams` / `rawQueryParams`
+Expression _rawParamValue(ParamConfig p) {
+  if (!p.hasConverter) return refer(p.name);
+  final valueRef = refer(p.name);
+  // auto-enums inline `value.name` to avoid building a throwaway converter
+  final serialized = p.converterInfo!.isEnumAuto
+      ? valueRef.property('name')
+      : _buildConverterRef(p).property('toParam').call([valueRef]);
+  if (p.type.isNullable) {
+    return valueRef.equalTo(literalNull).conditional(literalNull, serialized);
+  }
+  return serialized;
+}
+
+Expression _buildConverterRef(ParamConfig p) {
+  final info = p.converterInfo!;
+  if (info.isEnumAuto) {
+    return TypeReference((b) => b
+      ..symbol = 'EnumParamConverter'
+      ..url = 'package:auto_route/auto_route.dart'
+      ..types.add(_nonNullableRefer(info.convertedType))).constInstance([
+      refer(
+        '${info.convertedType.name}.values',
+        info.convertedType.import,
+      ),
+    ]);
+  }
+  return refer(info.variableName!, info.import);
 }
 
 extension _IterableX<T> on Iterable<T> {

--- a/auto_route_generator/lib/src/models/route_parameter_config.dart
+++ b/auto_route_generator/lib/src/models/route_parameter_config.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart' as cb;
 
+import '../resolvers/converter_resolver.dart';
 import 'resolved_type.dart';
 
 const _reservedVarNames = ['children'];
@@ -50,6 +51,15 @@ class ParamConfig {
   /// the default value code of the parameter
   final String? defaultValueCode;
 
+  /// info about a [ParamConverter] used to convert this parameter to/from the
+  /// URL; set from the `converter:` annotation arg or auto-synthesised for
+  /// enum types
+  final ConverterInfo? converterInfo;
+
+  /// true when read through a custom or auto-enum [ParamConverter] rather
+  /// than a built-in primitive getter
+  bool get hasConverter => converterInfo != null;
+
   /// Default constructor
   ParamConfig({
     required this.type,
@@ -65,6 +75,7 @@ class ParamConfig {
     required this.isInheritedPathParam,
     this.alias,
     this.defaultValueCode,
+    this.converterInfo,
   });
 
   /// If the parameter name conflicts with a reserved name
@@ -84,6 +95,9 @@ class ParamConfig {
   /// Return the getter function name
   /// based on the type of the parameter
   String get getterMethodName {
+    if (hasConverter) {
+      return type.isNullable ? 'optTyped' : 'getTyped';
+    }
     switch (type.name) {
       case 'String':
         return type.isNullable ? 'optString' : 'getString';
@@ -122,6 +136,7 @@ class ParamConfig {
       'isInheritedPathParam': isInheritedPathParam,
       'isQueryParam': isQueryParam,
       'defaultValueCode': defaultValueCode,
+      if (converterInfo != null) 'converterInfo': converterInfo!.toJson(),
     };
   }
 
@@ -145,6 +160,9 @@ class ParamConfig {
       isQueryParam: map['isQueryParam'] as bool,
       isUrlFragment: map['isUrlFragment'] as bool,
       defaultValueCode: map['defaultValueCode'] as String?,
+      converterInfo: map['converterInfo'] != null
+          ? ConverterInfo.fromJson((map['converterInfo'] as Map).cast<String, dynamic>())
+          : null,
     );
   }
 }

--- a/auto_route_generator/lib/src/resolvers/converter_resolver.dart
+++ b/auto_route_generator/lib/src/resolvers/converter_resolver.dart
@@ -29,7 +29,6 @@ class ConverterInfo {
   /// `getTyped<T>` / `optTyped<T>` calls
   final ResolvedType convertedType;
 
-  /// default const constructor
   const ConverterInfo({
     required this.convertedType,
     this.variableName,

--- a/auto_route_generator/lib/src/resolvers/converter_resolver.dart
+++ b/auto_route_generator/lib/src/resolvers/converter_resolver.dart
@@ -1,0 +1,159 @@
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:auto_route/annotations.dart';
+import 'package:source_gen/source_gen.dart';
+
+import '../../build_utils.dart';
+import '../models/resolved_type.dart';
+import 'type_resolver.dart';
+
+final _converterChecker = TypeChecker.typeNamed(ParamConverter, inPackage: 'auto_route');
+
+/// resolved info about the `converter:` argument on a `@PathParam` /
+/// `@QueryParam`, or about an auto-detected enum type
+class ConverterInfo {
+  /// name of the top-level const variable referenced from the annotation
+  /// (e.g. `dateConverter`); null when [isEnumAuto] is true
+  final String? variableName;
+
+  /// package URI of the library declaring [variableName]
+  /// (e.g. `package:my_app/converters.dart`); null when [isEnumAuto] is true
+  final String? import;
+
+  /// true when synthesised by the generator for an enum-typed parameter
+  /// without an explicit converter
+  final bool isEnumAuto;
+
+  /// the converted type `T`; used to emit the type argument on
+  /// `getTyped<T>` / `optTyped<T>` calls
+  final ResolvedType convertedType;
+
+  /// default const constructor
+  const ConverterInfo({
+    required this.convertedType,
+    this.variableName,
+    this.import,
+    this.isEnumAuto = false,
+  });
+
+  /// serializes to JSON for the build cache
+  Map<String, dynamic> toJson() => {
+        'variableName': variableName,
+        'import': import,
+        'isEnumAuto': isEnumAuto,
+        'convertedType': convertedType.toJson(),
+      };
+
+  /// deserializes from JSON
+  factory ConverterInfo.fromJson(Map<String, dynamic> map) => ConverterInfo(
+        variableName: map['variableName'] as String?,
+        import: map['import'] as String?,
+        isEnumAuto: map['isEnumAuto'] as bool? ?? false,
+        convertedType: ResolvedType.fromJson(map['convertedType']),
+      );
+}
+
+/// resolves the `converter:` annotation field, or auto-detects an
+/// enum-typed parameter
+///
+/// returns null when neither applies; throws [InvalidGenerationSourceError]
+/// with an actionable message for invalid usage
+ConverterInfo? resolveConverter({
+  required DartObject? converterObject,
+  required Element parameterElement,
+  required ResolvedType parameterType,
+  required DartType rawParamType,
+  required TypeResolver typeResolver,
+}) {
+  if (converterObject != null && !converterObject.isNull) {
+    return _resolveExplicitConverter(
+      converterObject: converterObject,
+      parameterElement: parameterElement,
+      parameterType: parameterType,
+      typeResolver: typeResolver,
+    );
+  }
+
+  // no explicit converter; auto-detect enum types
+  final element = rawParamType is InterfaceType ? rawParamType.element : null;
+  if (element is EnumElement) {
+    return ConverterInfo(
+      convertedType: parameterType,
+      isEnumAuto: true,
+    );
+  }
+  return null;
+}
+
+ConverterInfo _resolveExplicitConverter({
+  required DartObject converterObject,
+  required Element parameterElement,
+  required ResolvedType parameterType,
+  required TypeResolver typeResolver,
+}) {
+  final objectType = converterObject.type;
+  throwIf(
+    objectType == null || !_converterChecker.isAssignableFromType(objectType),
+    'The converter on [${parameterElement.displayName}] must implement '
+    'ParamConverter<T>. '
+    'Got: ${objectType?.getDisplayString() ?? 'unknown'}.',
+    element: parameterElement,
+  );
+
+  final variable = converterObject.variable;
+  throwIf(
+    variable == null,
+    'The converter on [${parameterElement.displayName}] must be a '
+    'top-level const variable, not an inline const expression. '
+    'Declare it once, e.g.\n'
+    '  const myConverter = MyConverter();\n'
+    'and reference it from the annotation:\n'
+    '  @QueryParam(\'name\', myConverter)',
+    element: parameterElement,
+  );
+
+  // confirm the converter's ParamConverter<T> type arg matches the
+  // parameter's declared type
+  final tArg = _extractConvertedType(objectType!);
+  if (tArg != null) {
+    final argDisplay = tArg.getDisplayString();
+    final paramDisplay = parameterType.name;
+    throwIf(
+      argDisplay != paramDisplay && '$argDisplay?' != paramDisplay,
+      'The converter on [${parameterElement.displayName}] handles '
+      'type [$argDisplay] but the parameter is declared as '
+      '[$paramDisplay].',
+      element: parameterElement,
+    );
+  }
+
+  // prefer the standard import resolver; fall back to the variable's declaring
+  // library URI for top-level consts in the same source asset
+  final import = typeResolver.resolveImport(variable) ?? variable!.library?.uri.toString();
+  throwIf(
+    import == null,
+    'Could not resolve the import for converter '
+    '[${variable!.displayName}] used on '
+    '[${parameterElement.displayName}].',
+    element: parameterElement,
+  );
+
+  return ConverterInfo(
+    convertedType: parameterType,
+    variableName: variable.displayName,
+    import: import,
+  );
+}
+
+/// walks [objectType]'s supertypes to find `ParamConverter<T>` and returns
+/// `T`, or null if undetermined
+DartType? _extractConvertedType(DartType objectType) {
+  if (objectType is! InterfaceType) return null;
+  for (final supertype in [objectType, ...objectType.allSupertypes]) {
+    if (_converterChecker.isExactlyType(supertype) && supertype.typeArguments.isNotEmpty) {
+      return supertype.typeArguments.first;
+    }
+  }
+  return null;
+}

--- a/auto_route_generator/lib/src/resolvers/route_config_resolver.dart
+++ b/auto_route_generator/lib/src/resolvers/route_config_resolver.dart
@@ -70,8 +70,10 @@ class RouteConfigResolver {
     if (pathParameters.isNotEmpty) {
       for (var pParam in pathParameters) {
         throwIf(
-          !validPathParamTypes.contains(pParam.type.name),
-          "Parameter [${pParam.name}] must be of a type that can be parsed from a [String] because it will also obtain it's value from a path\nvalid types: $validPathParamTypes",
+          !validPathParamTypes.contains(pParam.type.name) && !pParam.hasConverter,
+          "Parameter [${pParam.name}] must be of a type that can be parsed from a [String] because it will also obtain it's value from a path\n"
+          "valid types: $validPathParamTypes.\n"
+          "For other types provide a ParamConverter via @PathParam(name, myConverter) (enums are auto-detected).",
         );
       }
     }

--- a/auto_route_generator/lib/src/resolvers/route_parameter_resolver.dart
+++ b/auto_route_generator/lib/src/resolvers/route_parameter_resolver.dart
@@ -3,6 +3,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:auto_route/annotations.dart';
 
 import 'package:auto_route_generator/src/models/route_parameter_config.dart';
+import 'package:auto_route_generator/src/resolvers/converter_resolver.dart';
 import 'package:auto_route_generator/src/resolvers/type_resolver.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -75,6 +76,19 @@ class RouteParameterResolver {
       );
     }
 
+    // resolve explicit `converter:` arg, or auto-detect enum types
+    final hasParamAnnotation = pathParamAnnotation != null || queryParamAnnotation != null;
+    final converterInfo = hasParamAnnotation
+        ? resolveConverter(
+            converterObject:
+                pathParamAnnotation?.getField('converter') ?? queryParamAnnotation?.getField('converter'),
+            parameterElement: parameterElement,
+            parameterType: type,
+            rawParamType: paramType,
+            typeResolver: _typeResolver,
+          )
+        : null;
+
     return ParamConfig(
       type: type,
       name: paramName,
@@ -89,6 +103,7 @@ class RouteParameterResolver {
       isQueryParam: queryParamAnnotation != null,
       isUrlFragment: isUrlFragment,
       defaultValueCode: parameterElement.defaultValueCode,
+      converterInfo: converterInfo,
     );
   }
 


### PR DESCRIPTION

Closes #2148.

## What

Lets `@PathParam` and `@QueryParam` carry custom types — enums, `DateTime`, value objects — not only
`String` / `int` / `double` / `num` / `bool` / `List<String>`.

## Maintainer guidance

In the issue, the maintainer proposed a `ParamDeserializer<T>` with:

- a const unnamed constructor (enforced by the generator)
- a `fromParam(String?)` method
- a built-in generic enum deserializer
- deserialisation centralised in `Parameters` via `optTyped` / `getTyped`, mirroring `optInt` /
  `getInt`

## How this PR handles it

Same shape, with two changes:

1. **Renamed to `ParamConverter<T>` and added `toParam(T)`.**
   The annotation also drives outgoing URLs — `MyRoute(date: ...)` builds the path/query string — so
   a one-way deserialiser is not enough. `toParam` is the inverse of `fromParam`.

2. **Enums auto-detected.** When the param type is an `enum`, the generator emits
   `EnumParamConverter<T>(T.values)` for the user. No annotation argument needed.

For non-enum types, users extend `ParamConverter<T>`, declare a top-level `const` instance, and pass
it to the annotation:

```dart
@QueryParam('date', dateConverter) DateTime? date
```

## Design decisions

- **Bi-directional, not one-way.** `fromParam` + `toParam`. URLs must round-trip in both
  directions (deep link in, route built in code out).
- **Top-level `const` enforced by the generator.** Matches the existing `pathParam` / `queryParam`
  constants. Inline `const` expressions are rejected with a clear error.
- **Parse errors fall back to `defaultValue`.** `optTyped` catches exceptions from `fromParam`,
  mirroring `optInt` / `optDouble`. Malformed URLs do not crash navigation.
- **Logic lives in `Parameters`.** Added `optTyped<T>` / `getTyped<T>` next to the existing typed
  getters, so the same code path serves path and query params.
- **`null` from `toParam` drops the key.** Keeps outgoing query strings clean when a nullable value
  is absent.
